### PR TITLE
263 Initial draft of configure command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,10 @@ jobs:
         with:
           go-version: 1.16
       -
-        name: Find version
-        id: version
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: ${{ steps.version.outputs.tag }}
+          version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
-	"gopkg.in/nullstone.v0/config"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
 )
 
 var Configure = cli.Command{

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/nullstone-io/nullstone/v0/config"
+	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var Configure = cli.Command{
+	Name: "configure",
+	Action: func(c *cli.Context) error {
+		fmt.Print("Enter API Key: ")
+		bytePassword, err := terminal.ReadPassword(0)
+		if err != nil {
+			return fmt.Errorf("error reading password: %w", err)
+		}
+		fmt.Println()
+		if err := config.SaveApiKey(string(bytePassword)); err != nil {
+			return fmt.Errorf("unable to save API key: %w", err)
+		}
+		fmt.Println("nullstone configured successfully!")
+		return nil
+	},
+}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/nullstone-io/nullstone/v0/config"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/nullstone.v0/config"
 )
 
 var Configure = cli.Command{

--- a/config/api_key.go
+++ b/config/api_key.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+var (
+	ApiKeyFilename string
+)
+
+func init() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("unable to find home directory: %s\n", err)
+	}
+	ApiKeyFilename = path.Join(home, ".nullstone", "api-key")
+}
+
+func SaveApiKey(apiKey string) error {
+	if err := os.MkdirAll(filepath.Dir(ApiKeyFilename), 0755); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(ApiKeyFilename, []byte(apiKey), 0644)
+}
+
+func ReadApiKey() (string, error) {
+	if _, err := os.Stat(ApiKeyFilename); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	raw, err := ioutil.ReadFile(ApiKeyFilename)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/nullstone-io/nullstone/v0
 
 go 1.16
 
-require github.com/urfave/cli v1.22.5
+require (
+	github.com/urfave/cli v1.22.5
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/nullstone.v0
+module gopkg.in/nullstone-io/nullstone.v0
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nullstone-io/nullstone/v0
+module gopkg.in/nullstone.v0
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,14 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/urfave/cli"
-	"gopkg.in/nullstone.v0/cmd"
+	"gopkg.in/nullstone-io/nullstone.v0/cmd"
 	"log"
 	"os"
 	"sort"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"github.com/nullstone-io/nullstone/v0/cmd"
 	"github.com/urfave/cli"
 	"log"
 	"os"
@@ -22,7 +24,17 @@ func main() {
 			"date":    date,
 			"builtBy": builtBy,
 		},
-		Commands: []cli.Command{},
+		Flags: []cli.Flag{},
+		Commands: []cli.Command{
+			{
+				Name: "version",
+				Action: func(c *cli.Context) error {
+					fmt.Println(version)
+					return nil
+				},
+			},
+			cmd.Configure,
+		},
 	}
 	sort.Sort(cli.FlagsByName(app.Flags))
 	sort.Sort(cli.CommandsByName(app.Commands))

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/nullstone-io/nullstone/v0/cmd"
 	"github.com/urfave/cli"
+	"gopkg.in/nullstone.v0/cmd"
 	"log"
 	"os"
 	"sort"


### PR DESCRIPTION
This PR adds the `nullstone configure` CLI command.

This repo has already been configured (not tested yet) with `goreleaser` that will publish to GitHub Releases, Homebrew (mac), and Scoop (windows) from GitHub Actions when a `vx.y.z` tag is pushed.