### PR TITLE
263 Added context-specific organization to CLI

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -30,7 +30,7 @@ var Configure = cli.Command{
 		fmt.Println()
 
 		profile := config.Profile{
-			Name:    GetProfile(c.Parent()),
+			Name:    GetProfile(c),
 			Address: c.String("address"),
 			ApiKey:  string(rawApiKey),
 		}

--- a/cmd/flag_org.go
+++ b/cmd/flag_org.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/urfave/cli"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
+)
+
+// OrgFlag defines a flag that the CLI uses
+//   to contextualize API calls by that organization within Nullstone
+// The organization takes the following precedence:
+//   `--org` flag
+//   `NULLSTONE_ORG` env var
+//   `~/.nullstone/org` file
+var OrgFlag = cli.StringFlag{
+	Name:   "org",
+	EnvVar: "NULLSTONE_ORG",
+	Usage:  "Nullstone organization name used to contextualize API calls",
+}
+
+func GetOrg(c *cli.Context, profile config.Profile) string {
+	val := c.GlobalString(OrgFlag.Name)
+	if val == "" {
+		val, _ = profile.LoadOrg()
+	}
+	return val
+}

--- a/cmd/flag_profile.go
+++ b/cmd/flag_profile.go
@@ -10,7 +10,7 @@ var ProfileFlag = cli.StringFlag{
 }
 
 func GetProfile(c *cli.Context) string {
-	val := c.String(ProfileFlag.Name)
+	val := c.GlobalString(ProfileFlag.Name)
 	if val == "" {
 		return ProfileFlag.Value
 	}

--- a/cmd/set_org.go
+++ b/cmd/set_org.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/urfave/cli"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
+)
+
+var SetOrg = cli.Command{
+	Name:  "set-org",
+	Usage: "Set the organization for the CLI",
+	UsageText: `This commands sets the organization context for the CLI. 
+This will create a file at ~/.nullstone/org that is used by the CLI for commands that require an organization.`,
+	Flags: []cli.Flag{},
+	Action: func(c *cli.Context) error {
+		profile, err := config.LoadProfile(GetProfile(c.Parent()))
+		if err != nil {
+			return err
+		}
+
+		if c.NArg() != 1 {
+			return fmt.Errorf("invalid number of arguments, expected 1, got %d", c.NArg())
+		}
+		return profile.SaveOrg(c.Args().Get(0))
+	},
+}

--- a/config/profile.go
+++ b/config/profile.go
@@ -57,6 +57,23 @@ func LoadProfile(name string) (*Profile, error) {
 	return p, nil
 }
 
+func (p Profile) LoadOrg() (string, error) {
+	raw, err := ioutil.ReadFile(path.Join(p.Directory(), "org"))
+	if os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (p Profile) SaveOrg(org string) error {
+	if err := p.ensureDir(); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path.Join(p.Directory(), "org"), []byte(org), 0644)
+}
+
 func (p Profile) Directory() string {
 	return path.Join(NullstoneDir, p.Name)
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 				},
 			},
 			cmd.Configure,
+			cmd.SetOrg,
 		},
 	}
 	sort.Sort(cli.FlagsByName(app.Flags))

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 		},
 		Flags: []cli.Flag{
 			cmd.ProfileFlag,
+			cmd.OrgFlag,
 		},
 		Commands: []cli.Command{
 			{


### PR DESCRIPTION
This PR introduces a CLI command, CLI flag, and env var to contextualize commands to a nullstone organization:
- `nullstone --profile=<profile> set-org` - writes a file `~/.nullstone/<profile>/org` that is used for all commands when that profile is in use
- `nullstone --org=<org> ...` flag that overrides the organization to use when running CLI commands
  - This flag will use `NULLSTONE_ORG` env var if it exists in the environment