### PR TITLE
291+290 Built outputs retriever using struct tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.2.2
 	github.com/aws/smithy-go v1.3.1
+	github.com/stretchr/testify v1.2.2
 	github.com/urfave/cli v1.22.5
+	github.com/vmihailenco/tagparser v0.1.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210413123244-de7dbcaa6381
 )

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.6.1 h1:wHtZ+LSSQVwUSb+XIJ5E9hgAQxyWATZsAWT+ESJ9dQ0=

--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ func main() {
 			cmd.Configure,
 			cmd.SetOrg,
 			cmd.Deploy(appProviders),
-			cmd.Push(appProviders),
 		},
 	}
 	sort.Sort(cli.FlagsByName(cliApp.Flags))

--- a/outputs/errors.go
+++ b/outputs/errors.go
@@ -1,0 +1,33 @@
+package outputs
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type ErrInvalidContractField struct {
+	ObjectType reflect.Type
+	FieldType  reflect.Type
+	Message    string
+}
+
+func (e ErrInvalidContractField) Error() string {
+	return fmt.Sprintf("invalid contract field for (%s, %s), connection outputs must be decoded into a struct", e.ObjectType.Name(), e.FieldType.Name())
+}
+
+type ErrMissingRequiredConnection struct {
+	ConnectionName string
+	ConnectionType string
+}
+
+func (e ErrMissingRequiredConnection) Error() string {
+	return fmt.Sprintf("required connection missing (name=%s, type=%s)", e.ConnectionName, e.ConnectionType)
+}
+
+type ErrMissingRequiredOutput struct {
+	Name string
+}
+
+func (e ErrMissingRequiredOutput) Error() string {
+	return fmt.Sprintf("required output missing (name=%s)", e.Name)
+}

--- a/outputs/field.go
+++ b/outputs/field.go
@@ -1,0 +1,122 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/vmihailenco/tagparser"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"reflect"
+)
+
+var (
+	StructTag               = "ns"
+	StructTagConnectionName = "connectionName"
+	StructTagConnectionType = "connectionType"
+	StructTagOptional       = "optional"
+)
+
+/*
+Field is a representation of a struct tag that is specific to nullstone outputs
+You can define an output mapping directly to a workspace or to outputs through a connection in that workspace
+
+Examples:
+type Outputs struct {
+  Output1        string            `ns:"output1"`
+  OptionalOutput string            `ns:"optional_output,optional"`
+  MapOutput      map[string]string `ns:"map_output"`
+
+  Dependency DependencyOutputs `ns:",connectionType:some-dependency"`
+}
+
+type DependencyOutputs struct {
+  Output2 string `ns:"output2"`
+}
+
+Notes:
+  All fields that that map connections must be a well-defined struct
+  If you want to ignore a member in the struct, use `ns:"-"`
+  If you want to make a field/connection optional, add `ns:"output,optional"`
+*/
+type Field struct {
+	Field          reflect.StructField
+	Tag            string
+	Name           string
+	ConnectionType string
+	ConnectionName string
+	Optional       bool
+}
+
+func (f Field) SafeSet(sourceObj interface{}, outputs types.Outputs) error {
+	sourceType := reflect.TypeOf(sourceObj)
+	if sourceType.Kind() != reflect.Ptr {
+		return fmt.Errorf("source object must be a pointer")
+	}
+	if sourceType.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("source object must be a pointer to a struct")
+	}
+
+	var item types.OutputItem
+	var ok bool
+	if outputs != nil {
+		item, ok = outputs[f.Name]
+	}
+	if !ok {
+		if f.Optional {
+			return nil
+		}
+		return ErrMissingRequiredOutput{
+			Name: f.Name,
+		}
+	}
+
+	objVal := reflect.ValueOf(sourceObj).Elem()
+	fieldVal := objVal.FieldByName(f.Field.Name)
+	rawJsonEncoded, _ := json.Marshal(item.Value)
+	if err := json.Unmarshal(rawJsonEncoded, fieldVal.Addr().Interface()); err != nil {
+		return fmt.Errorf("could not deserialize output value from output %q: %w", f.Name, err)
+	}
+	return nil
+}
+
+func (f Field) InitializeConnectionValue(obj interface{}) interface{} {
+	objType := reflect.TypeOf(obj)
+	if objType.Kind() != reflect.Ptr {
+		return fmt.Errorf("source object must be a pointer")
+	}
+	if objType.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("source object must be a pointer to a struct")
+	}
+
+	objVal := reflect.ValueOf(obj).Elem()
+	fieldVal := objVal.FieldByName(f.Field.Name)
+	if fieldVal.Kind() == reflect.Ptr {
+		newPtr := reflect.New(f.Field.Type.Elem())
+		fieldVal.Set(newPtr)
+		return newPtr.Interface()
+	}
+	return fieldVal.Addr().Interface()
+}
+
+func GetFields(typ reflect.Type) []Field {
+	fields := make([]Field, 0)
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		field := Field{
+			Field: f,
+		}
+		field.Tag = f.Tag.Get(StructTag)
+		if field.Tag == "-" {
+			continue
+		}
+
+		structured := tagparser.Parse(field.Tag)
+		field.Name = structured.Name
+		field.ConnectionName = structured.Options[StructTagConnectionName]
+		field.ConnectionType = structured.Options[StructTagConnectionType]
+		field.Optional = structured.HasOption(StructTagOptional)
+
+		fields = append(fields, field)
+	}
+
+	return fields
+}

--- a/outputs/field_test.go
+++ b/outputs/field_test.go
@@ -1,0 +1,50 @@
+package outputs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestGetFields(t *testing.T) {
+	type DependencyOutputs struct {
+		Output2 string `ns:"output2"`
+	}
+	type Outputs struct {
+		Output1        string `ns:"output1"`
+		OptionalOutput string `ns:"optional_output,optional"`
+
+		Dependency DependencyOutputs `ns:",connectionType:some-dependency"`
+	}
+	outputsType := reflect.TypeOf(Outputs{})
+
+	want := []Field{
+		{
+			Field:          outputsType.Field(0),
+			Tag:            "output1",
+			Name:           "output1",
+			ConnectionType: "",
+			ConnectionName: "",
+			Optional:       false,
+		},
+		{
+			Field:          outputsType.Field(1),
+			Tag:            "optional_output,optional",
+			Name:           "optional_output",
+			ConnectionType: "",
+			ConnectionName: "",
+			Optional:       true,
+		},
+		{
+			Field:          outputsType.Field(2),
+			Tag:            ",connectionType:some-dependency",
+			Name:           "",
+			ConnectionType: "some-dependency",
+			ConnectionName: "",
+			Optional:       false,
+		},
+	}
+
+	got := GetFields(outputsType)
+	assert.Equal(t, want, got)
+}

--- a/outputs/mock_ns.go
+++ b/outputs/mock_ns.go
@@ -1,0 +1,35 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"log"
+	"net/http"
+	"net/http/httptest"
+)
+
+func mockNs(workspaces []types.Workspace) (*httptest.Server, api.Config) {
+	mux := http.NewServeMux()
+	for _, workspace := range workspaces {
+		endpoint := fmt.Sprintf("/orgs/%s/stacks/%s/blocks/%s/envs/%s",
+			workspace.OrgName, workspace.StackName, workspace.BlockName, workspace.EnvName)
+		mux.Handle(endpoint, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := json.Marshal(workspace)
+			w.Write(raw)
+		}))
+	}
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Println("unhandled endpoint in mock nullstone API", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+
+	server := httptest.NewServer(mux)
+	return server, api.Config{
+		BaseAddress:    server.URL,
+		ApiKey:         "invalid-api-key",
+		IsTraceEnabled: false,
+		OrgName:        "default",
+	}
+}

--- a/outputs/retriever.go
+++ b/outputs/retriever.go
@@ -1,0 +1,121 @@
+package outputs
+
+import (
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"reflect"
+)
+
+type Retriever struct {
+	NsConfig api.Config
+}
+
+// Retrieve is capable of retrieving all outputs for a given workspace
+// To properly use, the input obj must be a pointer to a struct that contains fields that map to outputs
+// Struct tags on each field within the struct define how to read the outputs from nullstone APIs
+// See Field for more details
+func (r *Retriever) Retrieve(workspace *types.Workspace, obj interface{}) error {
+	objType := reflect.TypeOf(obj)
+	if objType.Kind() != reflect.Ptr {
+		return fmt.Errorf("input object must be a pointer")
+	}
+	if objType.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("input object must be a pointer to a struct")
+	}
+
+	if workspace.LastSuccessfulRun == nil || workspace.LastSuccessfulRun.Apply == nil {
+		wt := types.WorkspaceTarget{
+			OrgName:   workspace.OrgName,
+			StackName: workspace.StackName,
+			BlockName: workspace.BlockName,
+			EnvName:   workspace.EnvName,
+		}
+		return fmt.Errorf("cannot find outputs for %s", wt.Id())
+	}
+	workspaceOutputs := workspace.LastSuccessfulRun.Apply.Outputs
+
+	fields := GetFields(reflect.TypeOf(obj).Elem())
+	for _, field := range fields {
+		fieldType := field.Field.Type
+
+		if field.Name == "" {
+			// `ns:",..."` refers to a connection, this field must be a struct type
+			//we're going to run retrieve into this field
+			if err := CheckValidConnectionField(obj, fieldType); err != nil {
+				return err
+			}
+			target := field.InitializeConnectionValue(obj)
+
+			connWorkspace, err := r.GetConnectionWorkspace(workspace, field.ConnectionName, field.ConnectionType)
+			if err != nil {
+				return fmt.Errorf("error finding connection workspace (name=%s, type=%s): %w", field.ConnectionName, field.ConnectionType, err)
+			}
+			if connWorkspace == nil {
+				if field.Optional {
+					continue
+				}
+				return ErrMissingRequiredConnection{
+					ConnectionName: field.ConnectionName,
+					ConnectionType: field.ConnectionType,
+				}
+			}
+			if err := r.Retrieve(connWorkspace, target); err != nil {
+				return err
+			}
+		} else {
+			// `ns:"xyz"` refers to an output named `xyz` in the current workspace outputs
+			// we're going to extract the value into this field
+			if err := CheckValidField(obj, fieldType); err != nil {
+				return err
+			}
+			if err := field.SafeSet(obj, workspaceOutputs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// GetConnectionWorkspace gets the workspace from nullstone through a connection from the source workspace
+// This will search through connections matching on connectionName and connectionType
+// Specify "" to ignore filtering for that field
+// One of either connectionName or connectionType must be specified
+func (r *Retriever) GetConnectionWorkspace(source *types.Workspace, connectionName, connectionType string) (*types.Workspace, error) {
+	conn, err := findConnection(source, connectionName, connectionType)
+	if err != nil {
+		return nil, err
+	} else if conn == nil {
+		return nil, nil
+	}
+
+	sourceTarget := types.WorkspaceTarget{
+		OrgName:   source.OrgName,
+		StackName: source.StackName,
+		BlockName: source.BlockName,
+		EnvName:   source.EnvName,
+	}
+	destTarget := sourceTarget.FindRelativeConnection(conn.Target)
+
+	nsClient := api.Client{Config: r.NsConfig}
+	return nsClient.Workspaces().Get(destTarget.StackName, destTarget.BlockName, destTarget.EnvName)
+}
+
+func findConnection(source *types.Workspace, connectionName, connectionType string) (*types.Connection, error) {
+	if source.LastSuccessfulRun == nil || source.LastSuccessfulRun.Config == nil {
+		return nil, fmt.Errorf("cannot find connections for app")
+	}
+	if connectionName == "" && connectionType == "" {
+		return nil, fmt.Errorf("cannot find connection if name or type is not specified")
+	}
+	for name, connection := range source.LastSuccessfulRun.Config.Connections {
+		if connectionType != "" && connectionType != connection.Type {
+			continue
+		}
+		if connectionName != "" && connectionName != name {
+			continue
+		}
+		return &connection, nil
+	}
+	return nil, nil
+}

--- a/outputs/retriever_test.go
+++ b/outputs/retriever_test.go
@@ -1,0 +1,128 @@
+package outputs
+
+import (
+	"github.com/nullstone-io/module/config"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"testing"
+)
+
+type MockFlatOutputs struct {
+	Output1 string            `ns:"output1"`
+	Output2 int               `ns:"output2"`
+	Output3 map[string]string `ns:"output3"`
+}
+
+type MockDeepOutputs struct {
+	Output1    string          `ns:"output1"`
+	Connection MockFlatOutputs `ns:",connectionType:aws-flat"`
+}
+
+func TestRetriever_Retrieve(t *testing.T) {
+	flatWorkspace := &types.Workspace{
+		OrgName:   "default",
+		StackName: "default",
+		BlockName: "flat0",
+		EnvName:   "dev",
+		LastSuccessfulRun: &types.Run{
+			Apply: &types.RunApply{
+				Outputs: types.Outputs{
+					"output1": types.OutputItem{
+						Type:      "string",
+						Value:     "value1",
+						Sensitive: false,
+					},
+					"output2": types.OutputItem{
+						Type:      "number",
+						Value:     2,
+						Sensitive: false,
+					},
+					"output3": types.OutputItem{
+						Type: "map(string)",
+						Value: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+							"key3": "value3",
+						},
+						Sensitive: false,
+					},
+				},
+			},
+		},
+	}
+	deepWorkspace := &types.Workspace{
+		OrgName:   "default",
+		StackName: "default",
+		BlockName: "deep0",
+		EnvName:   "dev",
+		LastSuccessfulRun: &types.Run{
+			Config: &types.RunConfig{
+				Connections: map[string]types.Connection{
+					"deep": {
+						Connection: config.Connection{
+							Type:     "aws-flat",
+							Optional: false,
+						},
+						Target: "deep0",
+						Unused: false,
+					},
+				},
+			},
+			Apply: &types.RunApply{
+				Outputs: types.Outputs{
+					"output1": types.OutputItem{
+						Type:      "string",
+						Value:     "test",
+						Sensitive: false,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("should retrieve outputs for single workspace", func(t *testing.T) {
+		want := MockFlatOutputs{
+			Output1: "value1",
+			Output2: 2,
+			Output3: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		}
+
+		retriever := Retriever{NsConfig: api.Config{}}
+		var got MockFlatOutputs
+		if assert.NoError(t, retriever.Retrieve(flatWorkspace, &got)) {
+			assert.Equal(t, want, got)
+		}
+	})
+
+	t.Run("should retrieve outputs for own workspace and connected workspace", func(t *testing.T) {
+		server, nsConfig := mockNs([]types.Workspace{
+			*deepWorkspace,
+			*flatWorkspace,
+		})
+		t.Cleanup(server.Close)
+
+		want := MockDeepOutputs{
+			Output1: "test",
+			Connection: MockFlatOutputs{
+				Output1: "value1",
+				Output2: 2,
+				Output3: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+					"key3": "value3",
+				},
+			},
+		}
+
+		retriever := Retriever{NsConfig: nsConfig}
+		var got MockDeepOutputs
+		if assert.NoError(t, retriever.Retrieve(deepWorkspace, &got)) {
+			assert.Equal(t, want, got)
+		}
+	})
+}

--- a/outputs/valid_fields.go
+++ b/outputs/valid_fields.go
@@ -1,0 +1,47 @@
+package outputs
+
+import "reflect"
+
+func CheckValidField(obj interface{}, fieldType reflect.Type) error {
+	fKind := fieldType.Kind()
+	isPtr := fKind == reflect.Ptr
+	if isPtr {
+		fKind = fieldType.Elem().Kind()
+	}
+
+	switch fKind {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128,
+		reflect.String,
+		reflect.Array, reflect.Slice,
+		reflect.Map, reflect.Struct:
+		return nil
+	default:
+		// we don't support Interface, Func, UnsafePointer, Chan as decode targets
+		// we also don't support double pointers: **<type>
+		return ErrInvalidContractField{
+			ObjectType: reflect.TypeOf(obj),
+			FieldType:  fieldType,
+			Message:    "invalid output field type",
+		}
+	}
+}
+
+func CheckValidConnectionField(obj interface{}, fieldType reflect.Type) error {
+	fKind := fieldType.Kind()
+	isPtr := fKind == reflect.Ptr
+	if isPtr {
+		fKind = fieldType.Elem().Kind()
+	}
+	switch fKind {
+	case reflect.Struct:
+		return nil
+	}
+	return ErrInvalidContractField{
+		ObjectType: reflect.TypeOf(obj),
+		FieldType:  fieldType,
+		Message:    "connections outputs must be decoded into a struct",
+	}
+}


### PR DESCRIPTION
This PR introduces `outputs.Retriever`.
The goal of this struct is to provide a simple, contract-based method for defining outputs in nullstone modules.
This is done through the use of struct tags on `Outputs` struct for each category+module type.

Since the `Retriever` is heavily tested, there is less likelihood of issues introduced when building for other app patterns and module types.

NOTE: I *could* see this going in another repo some day, but I left in the CLI until it becomes an issue.

As an example, the following structs define the outputs needed for performing actions on `aws-fargate-service`.

```
// contracts/aws-fargate-service

type Outputs struct {
	ServiceName  string          `ns:"service_name"`
	ImageRepoUrl docker.ImageUrl `ns:"image_repo_url,optional"`
	ImagePusher  aws.User        `ns:"image_pusher,optional"`

	Cluster aws_fargate.Outputs `ns:",connectionType:cluster/aws-fargate"`
}
```
// contracts/aws-fargate

```
type Outputs struct {
	ClusterArn string   `ns:"cluster_arn"`
	Deployer   aws.User `ns:"deployer"`
}
```