### PR TITLE
292 Lambda support

### DIFF
--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -42,7 +42,7 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, workspace *t
 	sourceUrl := docker.ParseImageUrl(userConfig["source"])
 
 	targetUrl := ic.Outputs.ImageRepoUrl
-	// NOTE: We expect --version from the user which is used as the image for the pushed image
+	// NOTE: We expect --version from the user which is used as the image tag for the pushed image
 	if imageTag := userConfig["version"]; imageTag != "" {
 		targetUrl.Tag = imageTag
 	} else {

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -42,7 +42,7 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, workspace *t
 	sourceUrl := docker.ParseImageUrl(userConfig["source"])
 
 	targetUrl := ic.Outputs.ImageRepoUrl
-	if imageTag := userConfig["imageTag"]; imageTag != "" {
+	if imageTag := userConfig["version"]; imageTag != "" {
 		targetUrl.Tag = imageTag
 	} else {
 		targetUrl.Tag = sourceUrl.Tag

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -42,6 +42,7 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, workspace *t
 	sourceUrl := docker.ParseImageUrl(userConfig["source"])
 
 	targetUrl := ic.Outputs.ImageRepoUrl
+	// NOTE: We expect --version from the user which is used as the image for the pushed image
 	if imageTag := userConfig["version"]; imageTag != "" {
 		targetUrl.Tag = imageTag
 	} else {

--- a/app/serverless/aws-lambda/infra_config.go
+++ b/app/serverless/aws-lambda/infra_config.go
@@ -34,7 +34,7 @@ func (c InfraConfig) UploadArtifact(ctx context.Context, content io.Reader, vers
 
 func (c InfraConfig) UpdateLambdaVersion(ctx context.Context, version string) error {
 	λClient := lambda.NewFromConfig(nsaws.NewConfig(c.Outputs.Deployer))
-	_, err := λClient.UpdateFunctionCode(context.TODO(), &lambda.UpdateFunctionCodeInput{
+	_, err := λClient.UpdateFunctionCode(ctx, &lambda.UpdateFunctionCodeInput{
 		FunctionName: aws.String(c.Outputs.LambdaName),
 		DryRun:       false,
 		Publish:      false,

--- a/app/serverless/aws-lambda/infra_config.go
+++ b/app/serverless/aws-lambda/infra_config.go
@@ -1,0 +1,45 @@
+package aws_lambda
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	nsaws "gopkg.in/nullstone-io/nullstone.v0/aws"
+	aws_lambda_service "gopkg.in/nullstone-io/nullstone.v0/contracts/aws-lambda-service"
+	"io"
+	"log"
+)
+
+// InfraConfig provides a minimal understanding of the infrastructure provisioned for a module type=aws-fargate
+type InfraConfig struct {
+	Outputs aws_lambda_service.Outputs
+}
+
+func (c InfraConfig) Print(logger *log.Logger) {
+	logger.Printf("lambda arn: %q\n", c.Outputs.LambdaArn)
+	logger.Printf("lambda name: %q\n", c.Outputs.LambdaName)
+	logger.Printf("artifacts bucket: %q\n", c.Outputs.ArtifactsBucketName)
+}
+
+func (c InfraConfig) UploadArtifact(ctx context.Context, content io.Reader, version string) error {
+	s3Client := s3.NewFromConfig(nsaws.NewConfig(c.Outputs.Deployer))
+	_, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(c.Outputs.ArtifactsBucketName),
+		Key:    aws.String(c.Outputs.ArtifactsKey(version)),
+		Body:   content,
+	})
+	return err
+}
+
+func (c InfraConfig) UpdateLambdaVersion(ctx context.Context, version string) error {
+	λClient := lambda.NewFromConfig(nsaws.NewConfig(c.Outputs.Deployer))
+	_, err := λClient.UpdateFunctionCode(context.TODO(), &lambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String(c.Outputs.LambdaName),
+		DryRun:       false,
+		Publish:      false,
+		S3Bucket:     aws.String(c.Outputs.ArtifactsBucketName),
+		S3Key:        aws.String(c.Outputs.ArtifactsKey(version)),
+	})
+	return err
+}

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -58,6 +58,7 @@ func (p Provider) Push(nsConfig api.Config, application *types.Application, work
 	}
 	defer file.Close()
 
+	logger.Printf("Uploading %s to artifacts bucket\n", ic.Outputs.ArtifactsKey(version), ic.Outputs.ArtifactsBucketName)
 	if err := ic.UploadArtifact(ctx, file, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -58,10 +58,12 @@ func (p Provider) Push(nsConfig api.Config, application *types.Application, work
 	}
 	defer file.Close()
 
-	logger.Printf("Uploading %s to artifacts bucket\n", ic.Outputs.ArtifactsKey(version), ic.Outputs.ArtifactsBucketName)
+	logger.Printf("Uploading %s to artifacts bucket\n", ic.Outputs.ArtifactsKey(version))
 	if err := ic.UploadArtifact(ctx, file, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
+
+	logger.Printf("Upload complete")
 
 	return nil
 }

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -83,7 +83,7 @@ func (p Provider) Deploy(nsConfig api.Config, application *types.Application, wo
 	}
 
 	logger.Printf("Deploying app %q\n", application.Name)
-	
+
 	logger.Printf("Updating app version to %q\n", version)
 	if err := app.UpdateVersion(nsConfig, application.Id, workspace.EnvName, version); err != nil {
 		return fmt.Errorf("error updating app version in nullstone: %w", err)

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -1,0 +1,99 @@
+package aws_lambda
+
+import (
+	"context"
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"gopkg.in/nullstone-io/nullstone.v0/outputs"
+	"log"
+	"os"
+)
+
+var (
+	logger = log.New(os.Stderr, "", 0)
+)
+
+var _ app.Provider = Provider{}
+
+type Provider struct {
+}
+
+func (p Provider) identify(nsConfig api.Config, app *types.Application, workspace *types.Workspace) (*InfraConfig, error) {
+	logger.Printf("Identifying infrastructure for app %q\n", app.Name)
+	ic := &InfraConfig{}
+	retriever := outputs.Retriever{NsConfig: nsConfig}
+	if err := retriever.Retrieve(workspace, &ic.Outputs); err != nil {
+		return nil, fmt.Errorf("Unable to identify app infrastructure: %w", err)
+	}
+	ic.Print(logger)
+	return ic, nil
+}
+
+// Push will upload the versioned artifact to the source artifact bucket for the lambda
+func (p Provider) Push(nsConfig api.Config, application *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, application, workspace)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add cancellation support so users can press Control+C to kill push
+	ctx := context.TODO()
+
+	source := userConfig["source"]
+	if source == "" {
+		return fmt.Errorf("--source is required to upload artifact")
+	}
+	version := userConfig["version"]
+	if version == "" {
+		return fmt.Errorf("--version is required to upload artifact")
+	}
+
+	file, err := os.Open(source)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("source file %q does not exist", source)
+	} else if err != nil {
+		return fmt.Errorf("error opening source file: %w", err)
+	}
+	defer file.Close()
+
+	if err := ic.UploadArtifact(ctx, file, version); err != nil {
+		return fmt.Errorf("error uploading artifact: %w", err)
+	}
+
+	return nil
+}
+
+// Deploy takes the following steps to deploy an AWS Lambda service
+//   Update app version in nullstone
+//   Update function code to use just-uploaded archive
+func (p Provider) Deploy(nsConfig api.Config, application *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, application, workspace)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add cancellation support so users can press Control+C to kill deploy
+	ctx := context.TODO()
+
+	version := userConfig["version"]
+	if version == "" {
+		return fmt.Errorf("--version is required to upload artifact")
+	}
+
+	logger.Printf("Deploying app %q\n", application.Name)
+	
+	logger.Printf("Updating app version to %q\n", version)
+	if err := app.UpdateVersion(nsConfig, application.Id, workspace.EnvName, version); err != nil {
+		return fmt.Errorf("error updating app version in nullstone: %w", err)
+	}
+
+	logger.Printf("Updating lambda to %q\n", version)
+	if err := ic.UpdateLambdaVersion(ctx, version); err != nil {
+		return fmt.Errorf("error updating lambda version: %w", err)
+	}
+
+	logger.Printf("Deployed app %q\n", application.Name)
+	return nil
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -13,14 +13,15 @@ var Deploy = func(providers app.Providers) cli.Command {
 		UsageText: "nullstone deploy <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "stack",
-				Usage: "The stack name where the app resides. This is only required if multiple apps have the same 'app-name'.",
+				Name: "stack",
+				Usage: `The stack name where the app resides.
+       This is only required if multiple apps have the same 'app-name'.`,
 			},
 			cli.StringFlag{
 				Name: "version",
 				Usage: `Update the application version.
-   For 'app/container' applications, the docker image tag will be set to the version.
-   If a version is not specified, the service will be redeployed with existing configuration`,
+       app/container: The docker image tag will be set to the version. If a version is not specified, the service will be redeployed with existing configuration.
+       app/serverless: The version of the artifact uploaded during 'push'. Version is required to use deploy command.`,
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -14,17 +14,28 @@ var Push = func(providers app.Providers) cli.Command {
 		UsageText: "nullstone push <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "stack",
-				Usage: "The stack name where the app resides. This is only required if multiple apps have the same 'app-name'.",
+				Name: "stack",
+				Usage: `The stack name where the app resides.
+       This is only required if multiple apps have the same 'app-name'.`,
 			},
 			cli.StringFlag{
-				Name:     "source",
-				Usage:    "The source docker image to push. This follows the same syntax as `docker push NAME[:TAG]`.",
+				Name: "source",
+				Usage: `The source artifact to push.
+       app/container: This is the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
+       app/serverless: This is a .zip archive to push.`,
 				Required: true,
 			},
 			cli.StringFlag{
-				Name:  "image-tag",
-				Usage: "Push the image with this tag instead of the source. If not specified, will use the source tag.",
+				Name: "image-tag",
+				Usage: `Push the image with this tag instead of the source. 
+       If not specified, will use the source tag.
+       This is only used for app/container applications.`,
+			},
+			cli.StringFlag{
+				Name: "version",
+				Usage: `Push the artifact with this version.
+       app/container: This is not used.
+       app/serverless: This is required to upload the artifact.`,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -42,6 +53,7 @@ var Push = func(providers app.Providers) cli.Command {
 			userConfig := map[string]string{
 				"source":   c.String("source"),
 				"imageTag": c.String("image-tag"),
+				"version":  c.String("version"),
 			}
 
 			finder := NsFinder{Config: cfg}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -26,15 +26,9 @@ var Push = func(providers app.Providers) cli.Command {
 				Required: true,
 			},
 			cli.StringFlag{
-				Name: "image-tag",
-				Usage: `Push the image with this tag instead of the source. 
-       If not specified, will use the source tag.
-       This is only used for app/container applications.`,
-			},
-			cli.StringFlag{
 				Name: "version",
 				Usage: `Push the artifact with this version.
-       app/container: This is not used.
+       app/container: If specified, will push the docker image with version as the image tag. Otherwise, uses source tag.
        app/serverless: This is required to upload the artifact.`,
 			},
 		},
@@ -51,9 +45,8 @@ var Push = func(providers app.Providers) cli.Command {
 			appName := c.Args().Get(0)
 			envName := c.Args().Get(1)
 			userConfig := map[string]string{
-				"source":   c.String("source"),
-				"imageTag": c.String("image-tag"),
-				"version":  c.String("version"),
+				"source":  c.String("source"),
+				"version": c.String("version"),
 			}
 
 			finder := NsFinder{Config: cfg}

--- a/contracts/aws-lambda-service/outputs.go
+++ b/contracts/aws-lambda-service/outputs.go
@@ -1,0 +1,22 @@
+package aws_lambda_service
+
+import (
+	"gopkg.in/nullstone-io/nullstone.v0/contracts/aws"
+	"strings"
+)
+
+const (
+	KeyTemplateAppVersion = "{{app-version}}"
+)
+
+type Outputs struct {
+	Deployer             aws.User `ns:"deployer"`
+	LambdaArn            string   `ns:"lambda_arn"`
+	LambdaName           string   `ns:"lambda_name"`
+	ArtifactsBucketName  string   `ns:"artifacts_bucket_name"`
+	ArtifactsKeyTemplate string   `ns:"artifacts_key_template"`
+}
+
+func (o Outputs) ArtifactsKey(appVersion string) string {
+	return strings.Replace(o.ArtifactsKeyTemplate, KeyTemplateAppVersion, appVersion, -1)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.2.2
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.2.2
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.2.2
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.5.0
 	github.com/aws/smithy-go v1.3.1
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.6+incompatible

--- a/go.sum
+++ b/go.sum
@@ -89,7 +89,16 @@ github.com/aws/aws-sdk-go-v2/service/ecr v1.2.2 h1:2EY0F1skAOArBsRM6nD9kPo0sdK32
 github.com/aws/aws-sdk-go-v2/service/ecr v1.2.2/go.mod h1:XnQfi4PwRBjy+CQD7zqVRRHKWe529+1nTsrWXvsSSJk=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.2.2 h1:Hel1rLI6Wjn/N1xAf7hVfqEPJxwwdOFFBG881M41fPI=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.2.2/go.mod h1:wfsCxzXu9fYoNl8NWbjc8OpC3ljwmL+5M/Zfa2xwm+M=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.4 h1:8yeByqOL6UWBsOOXsHnW93/ukwL66O008tRfxXxnTwA=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.4/go.mod h1:BCfU3Uo2fhKcMZFp9zU5QQGQxqWCOYmZ/27Dju3S/do=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.6 h1:ldYIsOP4WyjdzW8t6RC/aSieajrlx+3UN3UCZy1KM5Y=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.6/go.mod h1:L0KWr0ASo83PRZu9NaZaDsw3koS6PspKv137DMDZjHo=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.2 h1:aU8H58DoYxNo8R1TaSPTofkuxfQNnoqZmWL+G3+k/vA=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.2/go.mod h1:nnutjMLuna0s3GVY/MAkpLX03thyNER06gXvnMAPj5g=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.2.2 h1:F1vBHHT+x008mllAfLncqC0L2sgshS/ka1HFuL4jewc=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.2.2/go.mod h1:VjOrBW4srZJGZJmcyW00FDRVJFrBXoDlzd00vW4vCyw=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.5.0 h1:VbwXUI3L0hyhVmrFxbDxrs6cBX8TNFX0YxCpooMNjvY=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.5.0/go.mod h1:uwA7gs93Qcss43astPUb1eq4RyceNmYWAQjZFDOAMLo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.5/go.mod h1:bpGz0tidC4y39sZkQSkpO/J0tzWCMXHbw6FZ0j1GkWM=
 github.com/aws/aws-sdk-go-v2/service/sts v1.2.2/go.mod h1:ssRzzJ2RZOVuKj2Vx1YE7ypfil/BIlgmQnCSW4DistU=
 github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"gopkg.in/nullstone-io/nullstone.v0/app/container/aws-fargate"
+	aws_lambda "gopkg.in/nullstone-io/nullstone.v0/app/serverless/aws-lambda"
 	"gopkg.in/nullstone-io/nullstone.v0/cmd"
 	"os"
 	"sort"
@@ -27,7 +28,9 @@ func main() {
 		//types.CategoryAppStaticSite: {
 		//	"site/aws-s3": aws_s3_site.Provider{},
 		//},
-		//types.CategoryAppServerless: {},
+		types.CategoryAppServerless: {
+			"service/aws-lambda": aws_lambda.Provider{},
+		},
 	}
 
 	cliApp := &cli.App{


### PR DESCRIPTION
This PR implements the push/deploy provider for `app/serverless` => `aws-lambda`.

This also removes `--image-tag` CLI flag from `push` command. Instead, uses the `--version` CLI option.