### PR TITLE
Add support for 'main_container_name' output

### DIFF
--- a/contracts/aws-fargate-service/outputs.go
+++ b/contracts/aws-fargate-service/outputs.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Outputs struct {
-	ServiceName  string          `ns:"service_name"`
-	ImageRepoUrl docker.ImageUrl `ns:"image_repo_url,optional"`
-	ImagePusher  aws.User        `ns:"image_pusher,optional"`
+	ServiceName       string          `ns:"service_name"`
+	ImageRepoUrl      docker.ImageUrl `ns:"image_repo_url,optional"`
+	ImagePusher       aws.User        `ns:"image_pusher,optional"`
+	MainContainerName string          `ns:"main_container_name,optional"`
 
 	Cluster aws_fargate.Outputs `ns:",connectionType:cluster/aws-fargate"`
 }


### PR DESCRIPTION
This PR adds support for `main_container_name` output from fargate service.
This enables the CLI to run `deploy` commands when more than 1 container is running in the ECS service.

If the module does not emit `main_container_name` output, the user gets the following error:
```
service contains multiple containers; cannot deploy unless service module exports 'main_container_name'
```

If the `main_container_name` is not in the task definition, the user gets the following error:
```
cannot deploy service; no container definition with main_container_name = <main_container_name>
```