### PR TITLE
Fix usage of environment name

### DIFF
--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -33,7 +33,7 @@ func (p Provider) identify(nsConfig api.Config, app *types.Application, workspac
 	return ic, nil
 }
 
-func (p Provider) Push(nsConfig api.Config, app *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+func (p Provider) Push(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, app, workspace)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, workspace *t
 //   Register new task definition
 //   Deregister old task definition
 //   Update ECS Service (This always causes deployment)
-func (p Provider) Deploy(nsConfig api.Config, application *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+func (p Provider) Deploy(nsConfig api.Config, application *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, application, workspace)
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (p Provider) Deploy(nsConfig api.Config, application *types.Application, wo
 	taskDefArn := *taskDef.TaskDefinitionArn
 	if version != "" {
 		logger.Printf("Updating app version to %q\n", version)
-		if err := app.UpdateVersion(nsConfig, application.Id, workspace.EnvName, version); err != nil {
+		if err := app.UpdateVersion(nsConfig, application.Id, env.Name, version); err != nil {
 			return fmt.Errorf("error updating app version in nullstone: %w", err)
 		}
 

--- a/app/provider.go
+++ b/app/provider.go
@@ -11,6 +11,6 @@ import (
 //   - Modifying infrastructure to perform each command (e.g. push, deploy, etc.)
 //   - Each Provider is specific to Category+Type (Example: category=app/container, type=service/aws-fargate)
 type Provider interface {
-	Push(nsConfig api.Config, app *types.Application, workspace *types.Workspace, userConfig map[string]string) error
-	Deploy(nsConfig api.Config, app *types.Application, workspace *types.Workspace, userConfig map[string]string) error
+	Push(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error
+	Deploy(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error
 }

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -32,7 +32,7 @@ func (p Provider) identify(nsConfig api.Config, app *types.Application, workspac
 }
 
 // Push will upload the versioned artifact to the source artifact bucket for the lambda
-func (p Provider) Push(nsConfig api.Config, application *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+func (p Provider) Push(nsConfig api.Config, application *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, application, workspace)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (p Provider) Push(nsConfig api.Config, application *types.Application, work
 // Deploy takes the following steps to deploy an AWS Lambda service
 //   Update app version in nullstone
 //   Update function code to use just-uploaded archive
-func (p Provider) Deploy(nsConfig api.Config, application *types.Application, workspace *types.Workspace, userConfig map[string]string) error {
+func (p Provider) Deploy(nsConfig api.Config, application *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, application, workspace)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (p Provider) Deploy(nsConfig api.Config, application *types.Application, wo
 	logger.Printf("Deploying app %q\n", application.Name)
 
 	logger.Printf("Updating app version to %q\n", version)
-	if err := app.UpdateVersion(nsConfig, application.Id, workspace.EnvName, version); err != nil {
+	if err := app.UpdateVersion(nsConfig, application.Id, env.Name, version); err != nil {
 		return fmt.Errorf("error updating app version in nullstone: %w", err)
 	}
 

--- a/app/update_version.go
+++ b/app/update_version.go
@@ -7,9 +7,11 @@ import (
 
 func UpdateVersion(nsConfig api.Config, appId int64, envName, version string) error {
 	client := api.Client{Config: nsConfig}
-	_, err := client.AppEnvs().Update(appId, envName, version)
+	result, err := client.AppEnvs().Update(appId, envName, version)
 	if err != nil {
 		return fmt.Errorf("error updating app version: %w", err)
+	} else if result == nil {
+		return fmt.Errorf("could not find application environment")
 	}
 	return nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,7 +41,7 @@ var Deploy = func(providers app.Providers) cli.Command {
 			}
 
 			finder := NsFinder{Config: cfg}
-			app, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
+			app, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
 			if err != nil {
 				return err
 			}
@@ -50,7 +50,7 @@ var Deploy = func(providers app.Providers) cli.Command {
 			if provider == nil {
 				return fmt.Errorf("unable to deploy, this CLI does not support category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
 			}
-			return provider.Deploy(cfg, app, workspace, userConfig)
+			return provider.Deploy(cfg, app, env, workspace, userConfig)
 		},
 	}
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -50,7 +50,7 @@ var Push = func(providers app.Providers) cli.Command {
 			}
 
 			finder := NsFinder{Config: cfg}
-			app, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
+			app, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ var Push = func(providers app.Providers) cli.Command {
 				return fmt.Errorf("unable to push, this CLI does not support category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
 			}
 
-			return provider.Push(cfg, app, workspace, userConfig)
+			return provider.Push(cfg, app, env, workspace, userConfig)
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes the usage of environment name.

Previously, the CLI was using `workspace.EnvName` to perform lookups against nullstone.
When we tried the new CLI after moving to IDs, everything worked because `EnvName` still existed in the existing workspaces.
Once I tried the CLI against new workspaces, the deploy command failed because the env name was set to `""`.