### PR TITLE
C386/launch

### DIFF
--- a/app/container/aws-ecr/infra_config.go
+++ b/app/container/aws-ecr/infra_config.go
@@ -19,6 +19,7 @@ type InfraConfig struct {
 }
 
 func (c InfraConfig) Print(logger *log.Logger) {
+	logger = log.New(logger.Writer(), "    ", 0)
 	logger.Printf("repository image url: %q\n", c.Outputs.ImageRepoUrl)
 }
 

--- a/app/container/aws-ecr/provider.go
+++ b/app/container/aws-ecr/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"gopkg.in/nullstone-io/nullstone.v0/docker"
 	"gopkg.in/nullstone-io/nullstone.v0/outputs"
@@ -26,19 +25,19 @@ func (p Provider) DefaultLogProvider() string {
 	return "cloudwatch"
 }
 
-func (p Provider) identify(nsConfig api.Config, app *types.Application, workspace *types.Workspace) (*InfraConfig, error) {
-	logger.Printf("Identifying infrastructure for app %q\n", app.Name)
+func (p Provider) identify(nsConfig api.Config, details app.Details) (*InfraConfig, error) {
+	logger.Printf("Identifying infrastructure for app %q\n", details.App.Name)
 	ic := &InfraConfig{}
 	retriever := outputs.Retriever{NsConfig: nsConfig}
-	if err := retriever.Retrieve(workspace, &ic.Outputs); err != nil {
+	if err := retriever.Retrieve(details.Workspace, &ic.Outputs); err != nil {
 		return nil, fmt.Errorf("Unable to identify app infrastructure: %w", err)
 	}
 	ic.Print(logger)
 	return ic, nil
 }
 
-func (p Provider) Push(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
-	ic, err := p.identify(nsConfig, app, workspace)
+func (p Provider) Push(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, details)
 	if err != nil {
 		return err
 	}
@@ -88,11 +87,11 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, env *types.E
 }
 
 // Deploy updates the app version
-func (p Provider) Deploy(nsConfig api.Config, application *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
+func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	version := userConfig["version"]
 	if version != "" {
 		logger.Printf("Updating app version to %q\n", version)
-		if err := app.UpdateVersion(nsConfig, application.Id, env.Name, version); err != nil {
+		if err := app.UpdateVersion(nsConfig, details.App.Id, details.Env.Name, version); err != nil {
 			return fmt.Errorf("error updating app version in nullstone: %w", err)
 		}
 	}

--- a/app/container/aws-fargate/infra_config.go
+++ b/app/container/aws-fargate/infra_config.go
@@ -22,6 +22,7 @@ type InfraConfig struct {
 }
 
 func (c InfraConfig) Print(logger *log.Logger) {
+	logger = log.New(logger.Writer(), "    ", 0)
 	logger.Printf("fargate cluster: %q\n", c.Outputs.Cluster.ClusterArn)
 	logger.Printf("fargate service: %q\n", c.Outputs.ServiceName)
 	logger.Printf("repository image url: %q\n", c.Outputs.ImageRepoUrl)

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"gopkg.in/nullstone-io/nullstone.v0/docker"
 	"gopkg.in/nullstone-io/nullstone.v0/outputs"
@@ -26,19 +25,19 @@ func (p Provider) DefaultLogProvider() string {
 	return "cloudwatch"
 }
 
-func (p Provider) identify(nsConfig api.Config, app *types.Application, workspace *types.Workspace) (*InfraConfig, error) {
-	logger.Printf("Identifying infrastructure for app %q\n", app.Name)
+func (p Provider) identify(nsConfig api.Config, details app.Details) (*InfraConfig, error) {
+	logger.Printf("Identifying infrastructure for app %q\n", details.App.Name)
 	ic := &InfraConfig{}
 	retriever := outputs.Retriever{NsConfig: nsConfig}
-	if err := retriever.Retrieve(workspace, &ic.Outputs); err != nil {
+	if err := retriever.Retrieve(details.Workspace, &ic.Outputs); err != nil {
 		return nil, fmt.Errorf("Unable to identify app infrastructure: %w", err)
 	}
 	ic.Print(logger)
 	return ic, nil
 }
 
-func (p Provider) Push(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
-	ic, err := p.identify(nsConfig, app, workspace)
+func (p Provider) Push(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, details)
 	if err != nil {
 		return err
 	}
@@ -92,8 +91,8 @@ func (p Provider) Push(nsConfig api.Config, app *types.Application, env *types.E
 //   Register new task definition
 //   Deregister old task definition
 //   Update ECS Service (This always causes deployment)
-func (p Provider) Deploy(nsConfig api.Config, application *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error {
-	ic, err := p.identify(nsConfig, application, workspace)
+func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, details)
 	if err != nil {
 		return err
 	}
@@ -103,12 +102,12 @@ func (p Provider) Deploy(nsConfig api.Config, application *types.Application, en
 		return fmt.Errorf("error retrieving current service information: %w", err)
 	}
 
-	logger.Printf("Deploying app %q\n", application.Name)
+	logger.Printf("Deploying app %q\n", details.App.Name)
 	version := userConfig["version"]
 	taskDefArn := *taskDef.TaskDefinitionArn
 	if version != "" {
 		logger.Printf("Updating app version to %q\n", version)
-		if err := app.UpdateVersion(nsConfig, application.Id, env.Name, version); err != nil {
+		if err := app.UpdateVersion(nsConfig, details.App.Id, details.Env.Name, version); err != nil {
 			return fmt.Errorf("error updating app version in nullstone: %w", err)
 		}
 
@@ -124,6 +123,6 @@ func (p Provider) Deploy(nsConfig api.Config, application *types.Application, en
 		return fmt.Errorf("error deploying service: %w", err)
 	}
 
-	logger.Printf("Deployed app %q\n", application.Name)
+	logger.Printf("Deployed app %q\n", details.App.Name)
 	return nil
 }

--- a/app/details.go
+++ b/app/details.go
@@ -1,0 +1,9 @@
+package app
+
+import "gopkg.in/nullstone-io/go-api-client.v0/types"
+
+type Details struct {
+	App       *types.Application
+	Env       *types.Environment
+	Workspace *types.Workspace
+}

--- a/app/provider.go
+++ b/app/provider.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
 // Provider provides a standard interface to run commands against an app
@@ -12,6 +11,6 @@ import (
 //   - Each Provider is specific to Category+Type (Example: category=app/container, type=service/aws-fargate)
 type Provider interface {
 	DefaultLogProvider() string
-	Push(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error
-	Deploy(nsConfig api.Config, app *types.Application, env *types.Environment, workspace *types.Workspace, userConfig map[string]string) error
+	Push(nsConfig api.Config, details Details, userConfig map[string]string) error
+	Deploy(nsConfig api.Config, details Details, userConfig map[string]string) error
 }

--- a/app/serverless/aws-lambda/infra_config.go
+++ b/app/serverless/aws-lambda/infra_config.go
@@ -17,6 +17,7 @@ type InfraConfig struct {
 }
 
 func (c InfraConfig) Print(logger *log.Logger) {
+	logger = log.New(logger.Writer(), "    ", 0)
 	logger.Printf("lambda arn: %q\n", c.Outputs.LambdaArn)
 	logger.Printf("lambda name: %q\n", c.Outputs.LambdaName)
 	logger.Printf("artifacts bucket: %q\n", c.Outputs.ArtifactsBucketName)

--- a/app_logs/provider.go
+++ b/app_logs/provider.go
@@ -3,10 +3,10 @@ package app_logs
 import (
 	"context"
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"gopkg.in/nullstone-io/nullstone.v0/config"
 )
 
 type Provider interface {
-	Stream(ctx context.Context, nsConfig api.Config, app *types.Application, workspace *types.Workspace, options config.LogStreamOptions) error
+	Stream(ctx context.Context, nsConfig api.Config, details app.Details, options config.LogStreamOptions) error
 }

--- a/app_logs/providers.go
+++ b/app_logs/providers.go
@@ -3,7 +3,7 @@ package app_logs
 import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"gopkg.in/nullstone-io/nullstone.v0/outputs"
 	"log"
 	"os"
@@ -19,11 +19,11 @@ type outputsLogProvider struct {
 	LogProvider string `ns:"log_provider,optional"`
 }
 
-func (p Providers) Identify(defaultProvider string, nsConfig api.Config, app *types.Application, workspace *types.Workspace) (Provider, error) {
-	logger.Printf("Identifying log provider for app %q\n", app.Name)
+func (p Providers) Identify(defaultProvider string, nsConfig api.Config, details app.Details) (Provider, error) {
+	logger.Printf("Identifying log provider for app %q\n", details.App.Name)
 	lpOutputs := outputsLogProvider{}
 	retriever := outputs.Retriever{NsConfig: nsConfig}
-	if err := retriever.Retrieve(workspace, &lpOutputs); err != nil {
+	if err := retriever.Retrieve(details.Workspace, &lpOutputs); err != nil {
 		return nil, fmt.Errorf("Unable to identify app logger: %w", err)
 	}
 	if lpOutputs.LogProvider == "" {

--- a/cmd/app_action.go
+++ b/cmd/app_action.go
@@ -41,7 +41,7 @@ func AppAction(c *cli.Context, providers app.Providers, fn AppActionFn) error {
 
 	provider := providers.Find(workspace.Module.Category, workspace.Module.Type)
 	if provider == nil {
-		return fmt.Errorf("unable to push, this CLI does not support category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
+		return fmt.Errorf("this CLI does not support application category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
 	}
 
 	ctx := context.Background()

--- a/cmd/app_action.go
+++ b/cmd/app_action.go
@@ -5,20 +5,13 @@ import (
 	"fmt"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
-	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
-type AppDetails struct {
-	App       *types.Application
-	Env       *types.Environment
-	Workspace *types.Workspace
-}
-
-type AppActionFn func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error
+type AppActionFn func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error
 
 func AppAction(c *cli.Context, providers app.Providers, fn AppActionFn) error {
 	_, cfg, err := SetupProfileCmd(c)
@@ -34,7 +27,7 @@ func AppAction(c *cli.Context, providers app.Providers, fn AppActionFn) error {
 	envName := c.Args().Get(1)
 
 	finder := NsFinder{Config: cfg}
-	app, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
+	application, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
 	if err != nil {
 		return err
 	}
@@ -55,8 +48,8 @@ func AppAction(c *cli.Context, providers app.Providers, fn AppActionFn) error {
 		cancelFn()
 	}()
 
-	return fn(ctx, cfg, provider, AppDetails{
-		App:       app,
+	return fn(ctx, cfg, provider, app.Details{
+		App:       application,
 		Env:       env,
 		Workspace: workspace,
 	})

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -10,7 +10,7 @@ var Deploy = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
 		Name:      "deploy",
 		Usage:     "Deploy application",
-		UsageText: "nullstone deploy <app-name> <env-name> [options]",
+		UsageText: "nullstone deploy [options] <app-name> <env-name>",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppVersionFlag,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,11 +17,11 @@ var Deploy = func(providers app.Providers) *cli.Command {
 			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
-			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error {
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
 				userConfig := map[string]string{
 					"version": c.String("version"),
 				}
-				return provider.Deploy(cfg, details.App, details.Env, details.Workspace, userConfig)
+				return provider.Deploy(cfg, details, userConfig)
 			})
 		},
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -13,12 +13,7 @@ var Deploy = func(providers app.Providers) *cli.Command {
 		UsageText: "nullstone deploy <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
-			&cli.StringFlag{
-				Name: "version",
-				Usage: `Update the application version.
-       app/container: The docker image tag will be set to the version. If a version is not specified, the service will be redeployed with existing configuration.
-       app/serverless: The version of the artifact uploaded during 'push'. Version is required to use deploy command.`,
-			},
+			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
 			_, cfg, err := SetupProfileCmd(c)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -12,11 +12,7 @@ var Deploy = func(providers app.Providers) *cli.Command {
 		Usage:     "Deploy application",
 		UsageText: "nullstone deploy <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name: "stack",
-				Usage: `The stack name where the app resides.
-       This is only required if multiple apps have the same 'app-name'.`,
-			},
+			StackFlag,
 			&cli.StringFlag{
 				Name: "version",
 				Usage: `Update the application version.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"fmt"
+	"context"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 )
 
@@ -16,32 +17,12 @@ var Deploy = func(providers app.Providers) *cli.Command {
 			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
-			_, cfg, err := SetupProfileCmd(c)
-			if err != nil {
-				return err
-			}
-
-			if c.NArg() != 2 {
-				cli.ShowCommandHelp(c, "deploy")
-				return fmt.Errorf("invalid usage")
-			}
-			appName := c.Args().Get(0)
-			envName := c.Args().Get(1)
-			userConfig := map[string]string{
-				"version": c.String("version"),
-			}
-
-			finder := NsFinder{Config: cfg}
-			app, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
-			if err != nil {
-				return err
-			}
-
-			provider := providers.Find(workspace.Module.Category, workspace.Module.Type)
-			if provider == nil {
-				return fmt.Errorf("unable to deploy, this CLI does not support category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
-			}
-			return provider.Deploy(cfg, app, env, workspace, userConfig)
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error {
+				userConfig := map[string]string{
+					"version": c.String("version"),
+				}
+				return provider.Deploy(cfg, details.App, details.Env, details.Workspace, userConfig)
+			})
 		},
 	}
 }

--- a/cmd/flag_app_source.go
+++ b/cmd/flag_app_source.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "github.com/urfave/cli/v2"
+
+var AppSourceFlag = &cli.StringFlag{
+	Name: "source",
+	Usage: `The source artifact to push.
+       app/container: This is the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
+       app/serverless: This is a .zip archive to push.`,
+	Required: true,
+}

--- a/cmd/flag_app_version.go
+++ b/cmd/flag_app_version.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "github.com/urfave/cli/v2"
+
+var AppVersionFlag = &cli.StringFlag{
+	Name: "version",
+	Usage: `Push the artifact with this version.
+       app/container: If specified, will push the docker image with version as the image tag. Otherwise, uses source tag.
+       app/serverless: This is required to upload the artifact.`,
+}

--- a/cmd/flag_stack.go
+++ b/cmd/flag_stack.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/urfave/cli/v2"
+
+var StackFlag = &cli.StringFlag{
+	Name: "stack",
+	Usage: `The stack name where the app resides.
+       This is only required if multiple apps have the same 'app-name'.`,
+}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"gopkg.in/nullstone-io/nullstone.v0/app_logs"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
+	"log"
+	"os"
+)
+
+// Launch command performs push, deploy, and logs
+var Launch = func(providers app.Providers, logProviders app_logs.Providers) *cli.Command {
+	return &cli.Command{
+		Name:      "launch",
+		Usage:     "Launch application (push, deploy, log)",
+		UsageText: "nullstone launch [options] <app-name> <env-name>",
+		Flags: []cli.Flag{
+			StackFlag,
+			AppSourceFlag,
+			AppVersionFlag,
+		},
+		Action: func(c *cli.Context) error {
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
+				logger := log.New(os.Stderr, "", 0)
+
+				userConfig := map[string]string{
+					"source":  c.String("source"),
+					"version": c.String("version"),
+				}
+
+				logger.Println("Pushing app artifact...")
+				if err := provider.Push(cfg, details, userConfig); err != nil {
+					return fmt.Errorf("error pushing artifact: %w", err)
+				}
+				logger.Println()
+
+				logger.Println("Deploying application...")
+				if err := provider.Deploy(cfg, details, userConfig); err != nil {
+					return fmt.Errorf("error deploying app: %w", err)
+				}
+				logger.Println()
+
+				logger.Println("Tailing application logs...")
+				logProvider, err := logProviders.Identify(provider.DefaultLogProvider(), cfg, details)
+				if err != nil {
+					return err
+				}
+				return logProvider.Stream(ctx, cfg, details, config.LogStreamOptions{Out: os.Stdout})
+			})
+		},
+	}
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -53,7 +53,7 @@ var Logs = func(providers app.Providers, logProviders app_logs.Providers) *cli.C
 			},
 		},
 		Action: func(c *cli.Context) error {
-			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error {
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
 				logStreamOptions := config.LogStreamOptions{
 					WatchInterval: -1 * time.Second, // Disabled by default
 					Out:           os.Stdout,
@@ -73,11 +73,11 @@ var Logs = func(providers app.Providers, logProviders app_logs.Providers) *cli.C
 					}
 				}
 
-				logProvider, err := logProviders.Identify(provider.DefaultLogProvider(), cfg, details.App, details.Workspace)
+				logProvider, err := logProviders.Identify(provider.DefaultLogProvider(), cfg, details)
 				if err != nil {
 					return err
 				}
-				return logProvider.Stream(ctx, cfg, details.App, details.Workspace, logStreamOptions)
+				return logProvider.Stream(ctx, cfg, details, logStreamOptions)
 			})
 		},
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -17,11 +17,7 @@ var Logs = func(providers app.Providers, logProviders app_logs.Providers) *cli.C
 		Usage:     "Emit application logs",
 		UsageText: "nullstone logs <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name: "stack",
-				Usage: `The stack name where the app resides.
-       This is only required if multiple apps have the same 'app-name'.`,
-			},
+			StackFlag,
 			&cli.DurationFlag{
 				Name:        "start-time",
 				Aliases:     []string{"s"},

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -15,7 +15,7 @@ var Logs = func(providers app.Providers, logProviders app_logs.Providers) *cli.C
 	return &cli.Command{
 		Name:      "logs",
 		Usage:     "Emit application logs",
-		UsageText: "nullstone logs <app-name> <env-name> [options]",
+		UsageText: "nullstone logs [options] <app-name> <env-name>",
 		Flags: []cli.Flag{
 			StackFlag,
 			&cli.DurationFlag{

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -14,13 +14,7 @@ var Push = func(providers app.Providers) *cli.Command {
 		UsageText: "nullstone push <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
-			&cli.StringFlag{
-				Name: "source",
-				Usage: `The source artifact to push.
-       app/container: This is the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
-       app/serverless: This is a .zip archive to push.`,
-				Required: true,
-			},
+			AppSourceFlag,
 			&cli.StringFlag{
 				Name: "version",
 				Usage: `Push the artifact with this version.

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -13,11 +13,7 @@ var Push = func(providers app.Providers) *cli.Command {
 		Usage:     "Push artifact",
 		UsageText: "nullstone push <app-name> <env-name> [options]",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name: "stack",
-				Usage: `The stack name where the app resides.
-       This is only required if multiple apps have the same 'app-name'.`,
-			},
+			StackFlag,
 			&cli.StringFlag{
 				Name: "source",
 				Usage: `The source artifact to push.

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"fmt"
+	"context"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 )
 
@@ -18,34 +19,13 @@ var Push = func(providers app.Providers) *cli.Command {
 			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
-			_, cfg, err := SetupProfileCmd(c)
-			if err != nil {
-				return err
-			}
-
-			if c.NArg() != 2 {
-				cli.ShowCommandHelp(c, "push")
-				return fmt.Errorf("invalid usage")
-			}
-			appName := c.Args().Get(0)
-			envName := c.Args().Get(1)
-			userConfig := map[string]string{
-				"source":  c.String("source"),
-				"version": c.String("version"),
-			}
-
-			finder := NsFinder{Config: cfg}
-			app, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
-			if err != nil {
-				return err
-			}
-
-			provider := providers.Find(workspace.Module.Category, workspace.Module.Type)
-			if provider == nil {
-				return fmt.Errorf("unable to push, this CLI does not support category=%s, type=%s", workspace.Module.Category, workspace.Module.Type)
-			}
-
-			return provider.Push(cfg, app, env, workspace, userConfig)
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error {
+				userConfig := map[string]string{
+					"source":  c.String("source"),
+					"version": c.String("version"),
+				}
+				return provider.Push(cfg, details.App, details.Env, details.Workspace, userConfig)
+			})
 		},
 	}
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -15,12 +15,7 @@ var Push = func(providers app.Providers) *cli.Command {
 		Flags: []cli.Flag{
 			StackFlag,
 			AppSourceFlag,
-			&cli.StringFlag{
-				Name: "version",
-				Usage: `Push the artifact with this version.
-       app/container: If specified, will push the docker image with version as the image tag. Otherwise, uses source tag.
-       app/serverless: This is required to upload the artifact.`,
-			},
+			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
 			_, cfg, err := SetupProfileCmd(c)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -11,7 +11,7 @@ var Push = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
 		Name:      "push",
 		Usage:     "Push artifact",
-		UsageText: "nullstone push <app-name> <env-name> [options]",
+		UsageText: "nullstone push [options] <app-name> <env-name>",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppSourceFlag,

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -19,12 +19,12 @@ var Push = func(providers app.Providers) *cli.Command {
 			AppVersionFlag,
 		},
 		Action: func(c *cli.Context) error {
-			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details AppDetails) error {
+			return AppAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
 				userConfig := map[string]string{
 					"source":  c.String("source"),
 					"version": c.String("version"),
 				}
-				return provider.Push(cfg, details.App, details.Env, details.Workspace, userConfig)
+				return provider.Push(cfg, details, userConfig)
 			})
 		},
 	}

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -68,6 +68,7 @@ func main() {
 			cmd.Deploy(appProviders),
 			cmd.Push(appProviders),
 			cmd.Logs(appProviders, logProviders),
+			cmd.Launch(appProviders, logProviders),
 		},
 	}
 	sort.Sort(cli.FlagsByName(cliApp.Flags))


### PR DESCRIPTION
This PR adds the `launch` CLI command that performs `push`, `deploy`, and `log` (tailing logs).

While making a nice experience, the following changes were made:
- Reusing CLI flags across CLI commands
- Fixed usage text to notate `[options]` correctly (as a result of previous CLI upgrade)
- Reuse of common CLI setup for push, deploy, log, launch into single `AppAction`
  - Setting up profile
  - Finding information about application, environment, and workspace 
  - Discovering app provider
- Indenting output of infrastructure configuration

```
❯ nullstone launch -h                                                                                                                                                                             
NAME:
   nullstone launch - Launch application (push, deploy, log)

USAGE:
   nullstone launch [options] <app-name> <env-name>

OPTIONS:
   --stack value  The stack name where the app resides.
       This is only required if multiple apps have the same 'app-name'.
   --source value  The source artifact to push.
       app/container: This is the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
       app/serverless: This is a .zip archive to push.
   --version value  Push the artifact with this version.
       app/container: If specified, will push the docker image with version as the image tag. Otherwise, uses source tag.
       app/serverless: This is required to upload the artifact.
   --help, -h  show help (default: false)
   
```