### PR TITLE
Add org, app, stack, env to stderr output

### DIFF
--- a/cmd/app_action.go
+++ b/cmd/app_action.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -25,9 +26,14 @@ func AppAction(c *cli.Context, providers app.Providers, fn AppActionFn) error {
 	}
 	appName := c.Args().Get(0)
 	envName := c.Args().Get(1)
+	stackName := c.String("stack-name")
+
+	logger := log.New(os.Stderr, "", 0)
+	logger.Printf( "Performing application command (Org=%s, App=%s, Stack=%s, Env=%s)", cfg.OrgName, appName, stackName, envName)
+	logger.Println()
 
 	finder := NsFinder{Config: cfg}
-	application, env, workspace, err := finder.GetAppAndWorkspace(appName, c.String("stack-name"), envName)
+	application, env, workspace, err := finder.GetAppAndWorkspace(appName, stackName, envName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds command context to stderr so the user can track down issues.
```
❯ nullstone launch --source=arcana --version=0.1.0 arcana dev                                                                                                                                   
Performing application command (Org=nullstone, App=arcana, Stack=, Env=dev)

Pushing app artifact...
...
```