### PR TITLE
Soft move of deployer user to fargate service

### DIFF
--- a/app/container/aws-fargate/infra_config.go
+++ b/app/container/aws-fargate/infra_config.go
@@ -27,7 +27,7 @@ func (c InfraConfig) Print(logger *log.Logger) {
 }
 
 func (c InfraConfig) GetTaskDefinition() (*ecstypes.TaskDefinition, error) {
-	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.Cluster.Deployer, c.Outputs.Region))
+	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.GetDeployer(), c.Outputs.Region))
 
 	out1, err := ecsClient.DescribeServices(context.Background(), &ecs.DescribeServicesInput{
 		Services: []string{c.Outputs.ServiceName},
@@ -50,7 +50,7 @@ func (c InfraConfig) GetTaskDefinition() (*ecstypes.TaskDefinition, error) {
 }
 
 func (c InfraConfig) UpdateTaskImageTag(taskDefinition *ecstypes.TaskDefinition, imageTag string) (*ecstypes.TaskDefinition, error) {
-	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.Cluster.Deployer, c.Outputs.Region))
+	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.GetDeployer(), c.Outputs.Region))
 
 	defIndex, err := c.findMainContainerDefinitionIndex(taskDefinition.ContainerDefinitions)
 	if err != nil {
@@ -119,7 +119,7 @@ func (c InfraConfig) findMainContainerDefinitionIndex(containerDefs []ecstypes.C
 }
 
 func (c InfraConfig) GetService() (*ecstypes.Service, error) {
-	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.Cluster.Deployer, c.Outputs.Region))
+	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.GetDeployer(), c.Outputs.Region))
 	out, err := ecsClient.DescribeServices(context.Background(), &ecs.DescribeServicesInput{
 		Services: []string{c.Outputs.ServiceName},
 		Cluster:  aws.String(c.Outputs.Cluster.ClusterArn),
@@ -134,7 +134,7 @@ func (c InfraConfig) GetService() (*ecstypes.Service, error) {
 }
 
 func (c InfraConfig) GetTargetGroupHealth(targetGroupArn string) ([]elbv2types.TargetHealthDescription, error) {
-	elbClient := elasticloadbalancingv2.NewFromConfig(nsaws.NewConfig(c.Outputs.Cluster.Deployer, c.Outputs.Region))
+	elbClient := elasticloadbalancingv2.NewFromConfig(nsaws.NewConfig(c.Outputs.GetDeployer(), c.Outputs.Region))
 	out, err := elbClient.DescribeTargetHealth(context.Background(), &elasticloadbalancingv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(targetGroupArn),
 	})
@@ -145,7 +145,7 @@ func (c InfraConfig) GetTargetGroupHealth(targetGroupArn string) ([]elbv2types.T
 }
 
 func (c InfraConfig) UpdateServiceTask(taskDefinitionArn string) error {
-	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.Cluster.Deployer, c.Outputs.Region))
+	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(c.Outputs.GetDeployer(), c.Outputs.Region))
 
 	_, err := ecsClient.UpdateService(context.Background(), &ecs.UpdateServiceInput{
 		Service:            aws.String(c.Outputs.ServiceName),

--- a/contracts/aws-fargate-service/outputs.go
+++ b/contracts/aws-fargate-service/outputs.go
@@ -12,6 +12,14 @@ type Outputs struct {
 	ImageRepoUrl      docker.ImageUrl `ns:"image_repo_url,optional"`
 	ImagePusher       aws.User        `ns:"image_pusher,optional"`
 	MainContainerName string          `ns:"main_container_name,optional"`
+	Deployer          aws.User        `ns:"deployer,optional"`
 
 	Cluster aws_fargate.Outputs `ns:",connectionType:cluster/aws-fargate"`
+}
+
+func (o Outputs) GetDeployer() aws.User {
+	if o.Deployer.Name == "" {
+		return o.Cluster.Deployer
+	}
+	return o.Deployer
 }

--- a/contracts/aws-fargate/outputs.go
+++ b/contracts/aws-fargate/outputs.go
@@ -5,6 +5,9 @@ import (
 )
 
 type Outputs struct {
-	ClusterArn string   `ns:"cluster_arn"`
-	Deployer   aws.User `ns:"deployer"`
+	ClusterArn string `ns:"cluster_arn"`
+
+	// Deprecated: Deployer was moved to the fargate service in module v0.11.0+
+	// Remove "optional" from deployer in fargate service when removing
+	Deployer aws.User `ns:"deployer,optional"`
 }


### PR DESCRIPTION
This PR adds the deployer user to the fargate service outputs contract.
Because not all modules have been updated, this change is a forward-compatible change.
Once all usage of fargate service module is upgraded to v0.11.0+, we can drop `Deployer` user from cluster outputs.

This should be released before releasing:
- https://github.com/nullstone-modules/aws-fargate/pull/5
- https://github.com/nullstone-modules/aws-fargate-service/pull/26