### PR TITLE
C731 ec2 ssh

### DIFF
--- a/app/container/aws-ecr/provider.go
+++ b/app/container/aws-ecr/provider.go
@@ -97,7 +97,7 @@ func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig ma
 	return nil
 }
 
-func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	return fmt.Errorf("exec is not supported for the aws-ecr provider")
 }
 

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -1,6 +1,7 @@
 package aws_fargate
 
 import (
+	"context"
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
@@ -81,7 +82,7 @@ func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig ma
 	return nil
 }
 
-func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, details)
 	if err != nil {
 		return err

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -97,7 +97,7 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 		}
 	}
 
-	return ic.ExecCommand(task, userConfig["cmd"])
+	return ic.ExecCommand(ctx, task, userConfig["cmd"])
 }
 
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {

--- a/app/provider.go
+++ b/app/provider.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 )
 
@@ -35,7 +36,7 @@ type Provider interface {
 
 	// Exec allows a user to execute a command (usually tunneling) into a running service
 	// This only makes sense for container-based providers
-	Exec(nsConfig api.Config, details Details, userConfig map[string]string) error
+	Exec(ctx context.Context, nsConfig api.Config, details Details, userConfig map[string]string) error
 
 	// Status returns a high-level status report on the specified app env
 	Status(nsConfig api.Config, details Details) (StatusReport, error)

--- a/app/server/aws-ec2/infra_config.go
+++ b/app/server/aws-ec2/infra_config.go
@@ -1,0 +1,23 @@
+package aws_ec2
+
+import (
+	nsaws "gopkg.in/nullstone-io/nullstone.v0/aws"
+	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
+	aws_ec2 "gopkg.in/nullstone-io/nullstone.v0/contracts/aws-ec2"
+	"log"
+)
+
+type InfraConfig struct {
+	Outputs aws_ec2.Outputs
+}
+
+func (c InfraConfig) Print(logger *log.Logger) {
+	logger = log.New(logger.Writer(), "    ", 0)
+	logger.Printf("instance id: %q\n", c.Outputs.InstanceId)
+}
+
+func (c InfraConfig) ExecCommand() error {
+	region := c.Outputs.Region
+	awsConfig := nsaws.NewConfig(c.Outputs.Adminer, region)
+	return ssm.StartEc2Session(awsConfig, region, c.Outputs.InstanceId)
+}

--- a/app/server/aws-ec2/infra_config.go
+++ b/app/server/aws-ec2/infra_config.go
@@ -1,6 +1,7 @@
 package aws_ec2
 
 import (
+	"context"
 	nsaws "gopkg.in/nullstone-io/nullstone.v0/aws"
 	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
 	aws_ec2 "gopkg.in/nullstone-io/nullstone.v0/contracts/aws-ec2"
@@ -16,8 +17,9 @@ func (c InfraConfig) Print(logger *log.Logger) {
 	logger.Printf("instance id: %q\n", c.Outputs.InstanceId)
 }
 
-func (c InfraConfig) ExecCommand() error {
+func (c InfraConfig) ExecCommand(ctx context.Context, cmd string) error {
+	// TODO: Add support for cmd
 	region := c.Outputs.Region
 	awsConfig := nsaws.NewConfig(c.Outputs.Adminer, region)
-	return ssm.StartEc2Session(awsConfig, region, c.Outputs.InstanceId)
+	return ssm.StartEc2Session(ctx, awsConfig, region, c.Outputs.InstanceId)
 }

--- a/app/server/aws-ec2/provider.go
+++ b/app/server/aws-ec2/provider.go
@@ -1,6 +1,7 @@
 package aws_ec2
 
 import (
+	"context"
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
@@ -41,7 +42,7 @@ func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig ma
 	return fmt.Errorf("deploy is not supported for the aws-ec2 provider")
 }
 
-func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, details)
 	if err != nil {
 		return err

--- a/app/server/aws-ec2/provider.go
+++ b/app/server/aws-ec2/provider.go
@@ -1,0 +1,62 @@
+package aws_ec2
+
+import (
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"gopkg.in/nullstone-io/nullstone.v0/outputs"
+	"log"
+	"os"
+)
+
+var (
+	logger = log.New(os.Stderr, "", 0)
+)
+
+var _ app.Provider = Provider{}
+
+type Provider struct {
+}
+
+func (p Provider) DefaultLogProvider() string {
+	return "cloudwatch"
+}
+
+func (p Provider) identify(nsConfig api.Config, details app.Details) (*InfraConfig, error) {
+	logger.Printf("Identifying infrastructure for app %q\n", details.App.Name)
+	ic := &InfraConfig{}
+	retriever := outputs.Retriever{NsConfig: nsConfig}
+	if err := retriever.Retrieve(details.Workspace, &ic.Outputs); err != nil {
+		return nil, fmt.Errorf("Unable to identify app infrastructure: %w", err)
+	}
+	ic.Print(logger)
+	return ic, nil
+}
+
+func (p Provider) Push(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	return fmt.Errorf("push is not supported for the aws-ec2 provider")
+}
+
+func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	return fmt.Errorf("deploy is not supported for the aws-ec2 provider")
+}
+
+func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+	ic, err := p.identify(nsConfig, details)
+	if err != nil {
+		return err
+	}
+	if userConfig["cmd"] != "" {
+		return fmt.Errorf("'cmd' is not currently supported for the ec2 provider")
+	}
+
+	return ic.ExecCommand()
+}
+
+func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {
+	return app.StatusReport{}, fmt.Errorf("status is not supported for the aws-ec2 provider")
+}
+
+func (p Provider) StatusDetail(nsConfig api.Config, details app.Details) (app.StatusDetailReports, error) {
+	return app.StatusDetailReports{}, fmt.Errorf("status detail is not supported for the aws-ec2 provider")
+}

--- a/app/server/aws-ec2/provider.go
+++ b/app/server/aws-ec2/provider.go
@@ -47,11 +47,8 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 	if err != nil {
 		return err
 	}
-	if userConfig["cmd"] != "" {
-		return fmt.Errorf("'cmd' is not currently supported for the ec2 provider")
-	}
 
-	return ic.ExecCommand()
+	return ic.ExecCommand(ctx, userConfig["cmd"])
 }
 
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -103,7 +103,7 @@ func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig ma
 	return nil
 }
 
-func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	return fmt.Errorf("exec is not supported for the aws-lambda provider")
 }
 

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -65,7 +65,7 @@ func (p Provider) Push(nsConfig api.Config, details app.Details, userConfig map[
 	return nil
 }
 
-func (p Provider) Exec(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
+func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	return fmt.Errorf("exec is not supported for the aws-s3 provider")
 }
 

--- a/aws/ssm/ec2.go
+++ b/aws/ssm/ec2.go
@@ -8,6 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
+// StartEc2Session initiates an interactive SSH session with an EC2 instance using SSM
+// See setup guide: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html
+// In short, the following is necessary for this function to work
+//   - ec2 instance has SSM agent installed and registered
+//   - ec2 instance is configured with instance profile that has the AmazonSSMManagedInstanceCore policy attached (or an equivalent custom policy)
+//   - config contains an AWS identity that has access to ssm:StartSession on the EC2 Instance
 func StartEc2Session(config aws.Config, region, instanceId string) error {
 	ctx := context.Background()
 

--- a/aws/ssm/ec2.go
+++ b/aws/ssm/ec2.go
@@ -17,9 +17,8 @@ import (
 func StartEc2Session(ctx context.Context, config aws.Config, region, instanceId string) error {
 	ssmClient := ssm.NewFromConfig(config)
 	input := &ssm.StartSessionInput{
-		Target:       aws.String(instanceId),
-		DocumentName: aws.String("AWS-StartSSHSession"),
-		Reason:       aws.String("nullstone exec"),
+		Target: aws.String(instanceId),
+		Reason: aws.String("nullstone exec"),
 	}
 	out, err := ssmClient.StartSession(ctx, input)
 	if err != nil {

--- a/aws/ssm/ec2.go
+++ b/aws/ssm/ec2.go
@@ -1,0 +1,29 @@
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+func StartEc2Session(config aws.Config, region, instanceId string) error {
+	ctx := context.Background()
+
+	ssmClient := ssm.NewFromConfig(config)
+	input := &ssm.StartSessionInput{
+		Target:       aws.String(instanceId),
+		DocumentName: aws.String("AWS-StartSSHSession"),
+		Reason:       aws.String("nullstone exec"),
+	}
+	out, err := ssmClient.StartSession(ctx, input)
+	if err != nil {
+		return fmt.Errorf("error establishing ecs execute command: %w", err)
+	}
+
+	er := ec2.NewDefaultEndpointResolver()
+	endpoint, _ := er.ResolveEndpoint(region, ec2.EndpointResolverOptions{})
+
+	return StartSession(ctx, out, region, instanceId, endpoint.URL)
+}

--- a/aws/ssm/ecs.go
+++ b/aws/ssm/ecs.go
@@ -10,7 +10,6 @@ import (
 
 func StartEcsSession(ctx context.Context, config aws.Config, region, cluster, taskId, containerName, cmd string) error {
 	ecsClient := ecs.NewFromConfig(config)
-
 	input := &ecs.ExecuteCommandInput{
 		Cluster:     aws.String(cluster),
 		Task:        aws.String(taskId),
@@ -18,7 +17,6 @@ func StartEcsSession(ctx context.Context, config aws.Config, region, cluster, ta
 		Command:     aws.String(cmd),
 		Interactive: true,
 	}
-
 	out, err := ecsClient.ExecuteCommand(context.Background(), input)
 	if err != nil {
 		return fmt.Errorf("error establishing ecs execute command: %w", err)

--- a/aws/ssm/ecs.go
+++ b/aws/ssm/ecs.go
@@ -1,0 +1,22 @@
+package ssm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+func StartEcsSession(session *ecstypes.Session, region, cluster, task, containerName string) error {
+	targetRaw, _ := json.Marshal(ssm.StartSessionInput{
+		Target: aws.String(fmt.Sprintf("ecs:%s_%s_%s", cluster, task, containerName)),
+	})
+
+	er := ecs.NewDefaultEndpointResolver()
+	endpoint, _ := er.ResolveEndpoint(region, ecs.EndpointResolverOptions{})
+
+	return StartSession(context.Background(), session, region, string(targetRaw), endpoint.URL)
+}

--- a/aws/ssm/plugin.go
+++ b/aws/ssm/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"os"
 	"os/exec"
 )
@@ -13,19 +14,20 @@ const (
 	sessionManagerUrl    = "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
 )
 
-func StartSession(ctx context.Context, session interface{}, region, target, endpointUrl string) error {
+func StartSession(ctx context.Context, session interface{}, target ssm.StartSessionInput, region, endpointUrl string) error {
 	process, err := getSessionManagerPluginPath()
 	if err != nil {
 		return fmt.Errorf("could not find AWS session-manager-plugin: %w", err)
 	}
 
 	sessionJsonRaw, _ := json.Marshal(session)
+	targetRaw, _ := json.Marshal(target)
 	args := []string{
 		string(sessionJsonRaw),
 		region,
 		"StartSession",
 		"", // empty profile name
-		target,
+		string(targetRaw),
 		endpointUrl,
 	}
 	cmd := exec.CommandContext(ctx, process, args...)

--- a/aws/ssm/plugin.go
+++ b/aws/ssm/plugin.go
@@ -4,70 +4,36 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ecs"
-	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"os"
 	"os/exec"
-	"os/signal"
-	"syscall"
 )
 
-type EcsSession struct {
-	Cluster       string
-	TaskId        string
-	ContainerName string
-}
+const (
+	sessionManagerBinary = "session-manager-plugin"
+	sessionManagerUrl    = "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
+)
 
-func StartEcsSession(session *ecstypes.Session, region, cluster, task, containerName string) error {
-	sessionJsonRaw, _ := json.Marshal(session)
-	targetRaw, _ := json.Marshal(ssm.StartSessionInput{
-		Target: aws.String(fmt.Sprintf("ecs:%s_%s_%s", cluster, task, containerName)),
-	})
-
-	er := ecs.NewDefaultEndpointResolver()
-	endpoint, _ := er.ResolveEndpoint(region, ecs.EndpointResolverOptions{})
-
-	args := []string{
-		string(sessionJsonRaw),
-		region,
-		"StartSession",
-		"", // empty profile name
-		string(targetRaw),
-		endpoint.URL,
-	}
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt, syscall.SIGINT)
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		for {
-			select {
-			case <-sigs:
-				cancel()
-				return
-			}
-		}
-	}()
-	defer close(sigs)
-
+func StartSession(ctx context.Context, session interface{}, region, target, endpointUrl string) error {
 	process, err := getSessionManagerPluginPath()
 	if err != nil {
 		return fmt.Errorf("could not find AWS session-manager-plugin: %w", err)
 	}
 
+	sessionJsonRaw, _ := json.Marshal(session)
+	args := []string{
+		string(sessionJsonRaw),
+		region,
+		"StartSession",
+		"", // empty profile name
+		target,
+		endpointUrl,
+	}
 	cmd := exec.CommandContext(ctx, process, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	return cmd.Run()
 }
-
-const (
-	sessionManagerBinary = "session-manager-plugin"
-	sessionManagerUrl    = "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-)
 
 // getSessionManagerPluginPath attempts to find "session-manager-plugin"
 // If it's in PATH, will simply return binary name

--- a/cmd/cancellable_action.go
+++ b/cmd/cancellable_action.go
@@ -9,14 +9,6 @@ import (
 
 func CancellableAction(fn func(ctx context.Context) error) error {
 	ctx := context.Background()
-	// Handle Ctrl+C, kill stream
-	ctx, cancelFn := context.WithCancel(ctx)
-	defer cancelFn()
-	term := make(chan os.Signal, 1)
-	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-term
-		cancelFn()
-	}()
+	signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	return fn(ctx)
 }

--- a/cmd/cancellable_action.go
+++ b/cmd/cancellable_action.go
@@ -8,7 +8,7 @@ import (
 )
 
 func CancellableAction(fn func(ctx context.Context) error) error {
-	ctx := context.Background()
-	signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	return fn(ctx)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -28,7 +28,7 @@ var Exec = func(providers app.Providers) *cli.Command {
 			}
 
 			return AppEnvAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
-				return provider.Exec(cfg, details, userConfig)
+				return provider.Exec(ctx, cfg, details, userConfig)
 			})
 		},
 	}

--- a/contracts/aws-ec2/outputs.go
+++ b/contracts/aws-ec2/outputs.go
@@ -1,0 +1,9 @@
+package aws_ec2
+
+import "gopkg.in/nullstone-io/nullstone.v0/contracts/aws"
+
+type Outputs struct {
+	Region     string   `ns:"region"`
+	InstanceId string   `ns:"instance_id"`
+	Adminer    aws.User `ns:"adminer,optional"`
+}

--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,9 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.3.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.7.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.7.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.20.0
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudfront v1.8.2 h1:EZwLcvmj+y2sn1DEH86ja7
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.8.2/go.mod h1:SCoyx6YKezLdYuFcbhuV4EShiu66Gr4BbNMmqr0BFFE=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.7.2 h1:Ytlx4bQ6Nsnd1ZUOknHEZaXTQyWoY1wdCXiT1MnujeI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.7.2/go.mod h1:OMEa8/xxAnMr21Pcl8fYr1oH1mwwWCBh+whUuJrrEPk=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.29.0 h1:7jk4NfzDnnSbaR9E4mOBWRZXQThq5rsqjlDC+uu9dsI=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.29.0/go.mod h1:HoTu0hnXGafTpKIZQ60jw0ybhhCH1QYf20oL7GEJFdg=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.7.1 h1:ido0AMjccjxFXFCDpL0wBhx7CnPbhY5QpcFihz7dcjo=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.7.1/go.mod h1:qAlEzAqi1r8VgxbeW2hFhX4+6289+twWZJgzu2CtgnA=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.9.2 h1:5Gmw7ets6uAzwVT4XZYQaEbRIilnocz307veedDGoeA=
@@ -140,8 +142,9 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.9.0 h1:m+j2j5Nomq
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.9.0/go.mod h1:AtEwsM+3UFLpJLIj2ys+Uc1WpaXECCv067AswxpKU+U=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.3.0 h1:gceOysEWNNwLd6cki65IMBZ4WAM0MwgBQq2n7kejoT8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.3.0/go.mod h1:v8ygadNyATSm6elwJ/4gzJwcFhri9RqS8skgHKiwXPU=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.2 h1:r7jel2aa4d9Duys7wEmWqDd5ebpC9w6Kxu6wIjjp18E=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.2/go.mod h1:72HRZDLMtmVQiLG2tLfQcaWLCssELvGl+Zf2WVxMmR8=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.7.0 h1:4QAOB3KrvI1ApJK14sliGr3Ie2pjyvNypn/lfzDHfUw=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.7.0/go.mod h1:K/qPe6AP2TGYv4l6n7c88zh9jWBDf6nHhvg1fx/EWfU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.7.2 h1:RnZjLgtCGLsF2xYYksy0yrx6xPvKG9BYv29VfK4p/J8=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.7.2/go.mod h1:np7TMuJNT83O0oDOSF8i4dF3dvGqA6hPYYo6YYkzgRA=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.9.1 h1:xDnEGBvB7NmaetDI4e7f3+AxGmOhq1QySgUgA9S2pQo=

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	aws_ecr "gopkg.in/nullstone-io/nullstone.v0/app/container/aws-ecr"
 	"gopkg.in/nullstone-io/nullstone.v0/app/container/aws-fargate"
+	aws_ec2 "gopkg.in/nullstone-io/nullstone.v0/app/server/aws-ec2"
 	aws_lambda "gopkg.in/nullstone-io/nullstone.v0/app/serverless/aws-lambda"
 	aws_s3 "gopkg.in/nullstone-io/nullstone.v0/app/static-site/aws-s3"
 	"gopkg.in/nullstone-io/nullstone.v0/app_logs"
@@ -34,6 +35,9 @@ func main() {
 		},
 		types.CategoryAppServerless: {
 			"service/aws-lambda": aws_lambda.Provider{},
+		},
+		types.CategoryAppServer: {
+			"service/aws-ec2": aws_ec2.Provider{},
 		},
 	}
 	logProviders := app_logs.Providers{

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -37,7 +37,7 @@ func main() {
 			"service/aws-lambda": aws_lambda.Provider{},
 		},
 		types.CategoryAppServer: {
-			"service/aws-ec2": aws_ec2.Provider{},
+			"server/aws-ec2": aws_ec2.Provider{},
 		},
 	}
 	logProviders := app_logs.Providers{


### PR DESCRIPTION
This PR adds support for `server/aws-ec2` provider.
This provider falls under the `app/server` category.

Currently, this provider *only* supports the `exec` command.

Additionally, cancellation (via `SIGTERM` or `SIGINT`) was enabled for `provider.Exec`.
