### PR TITLE
C840 up vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.0.53 (May 10, 2022)
+* Improved `nullstone up` to set variable `Value` to `Default` if `nil`. 
+
+# 0.0.52 (Apr 01, 2022)
+* Fixed usage of `StackId` in Deploys endpoint.
+
+# 0.0.51 (Apr 01, 2022)
+* Migrated "Update AppEnvs" endpoint to new "Create Deploy" endpoint. 
+
+# 0.0.50 (Mar 17, 2022)
+* Removed use of deprecated public module endpoints.
+
 # 0.0.49 (Mar 01, 2022)
 * Fixed `up` command:
   * If an error occurs when creating the run, do not attempt to stream the logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.53 (May 10, 2022)
-* Improved `nullstone up` to set variable `Value` to `Default` if `nil`. 
+* Improved `nullstone up` to set variable `Value` to `Default` if `nil`.
+* Added `--var` to `nullstone up` to specify Terraform variables upon launch.
 
 # 0.0.52 (Apr 01, 2022)
 * Fixed usage of `StackId` in Deploys endpoint.

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -177,8 +177,6 @@ func setRunConfigVars(rc *types.RunConfig, varFlags []string) ([]string, error) 
 			continue
 		}
 		name, value := tokens[0], tokens[1]
-		// Look in RunConfig for variable matching `name`
-		// If we don't find a matching variable, we just skip it
 		if v, ok := rc.Variables[name]; ok {
 			if out, err := parseVarFlag(v, name, value); err != nil {
 				errs = append(errs, err.Error())


### PR DESCRIPTION
Added `--var` to `nullstone up` allowing users to specify Terraform variable values upon launch.

This is especially helpful for the quickstarts where a `service_port` is different:
```
nullstone up --app=app --env=dev --var=service_port=8000
```

This `--var` performs light validation of the input data. Here is an example of invalid input:
```
$ nullstone up --block=test --env=dev -var=service_count=fail -var=service_cpu=x
Performing workspace command (Org=demo, Block=test, Stack=, Env=dev)

"--var" flags contain invalid values:
    * service_count: expected 'number' - strconv.ParseFloat: parsing "fail": invalid syntax
    * service_cpu: expected 'number' - strconv.ParseFloat: parsing "x": invalid syntax
```