### PR TITLE
`nullstone ssh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.56 (May 30, 2022)
+* Added `ssh` command
+  * Supports ssh for `aws-fargate` and `aws-ec2` providers.
+  * Support port forwarding `--forward/-L` for `aws-ec2` provider.
+
 # 0.0.54 (May 18, 2022)
 * Fixed issue with `nullstone publish` including `v` prefix in version number.
 

--- a/app/container/aws-ecr/provider.go
+++ b/app/container/aws-ecr/provider.go
@@ -101,6 +101,10 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 	return fmt.Errorf("exec is not supported for the aws-ecr provider")
 }
 
+func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
+	return fmt.Errorf("ssh is not supported for the aws-ecr provider")
+}
+
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {
 	return app.StatusReport{}, nil
 }

--- a/app/container/aws-fargate/infra_config.go
+++ b/app/container/aws-fargate/infra_config.go
@@ -181,11 +181,11 @@ func (c InfraConfig) GetRandomTask() (string, error) {
 	return "", nil
 }
 
-func (c InfraConfig) ExecCommand(ctx context.Context, taskId string, cmd string) error {
+func (c InfraConfig) ExecCommand(ctx context.Context, taskId string, cmd string, parameters map[string][]string) error {
 	region := c.Outputs.Region
 	cluster := c.Outputs.Cluster.ClusterArn
 	containerName := c.Outputs.MainContainerName
 	awsConfig := nsaws.NewConfig(c.Outputs.GetDeployer(), region)
 
-	return ssm.StartEcsSession(ctx, awsConfig, region, cluster, taskId, containerName, cmd)
+	return ssm.StartEcsSession(ctx, awsConfig, region, cluster, taskId, containerName, cmd, parameters)
 }

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -6,7 +6,6 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	aws_ecr "gopkg.in/nullstone-io/nullstone.v0/app/container/aws-ecr"
-	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
 	"gopkg.in/nullstone-io/nullstone.v0/config"
 	"gopkg.in/nullstone-io/nullstone.v0/outputs"
 	"log"
@@ -117,14 +116,11 @@ func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Deta
 		}
 	}
 
-	var parameters map[string][]string
-	if val, ok := userConfig["forwards"].([]config.PortForward); ok {
-		if parameters, err = ssm.SessionParametersFromPortForwards(val); err != nil {
-			return err
-		}
+	if forwards, ok := userConfig["forwards"].([]config.PortForward); ok && len(forwards) > 0 {
+		return fmt.Errorf("aws-fargate does not support port forwarding")
 	}
 
-	return ic.ExecCommand(ctx, task, "/bin/sh", parameters)
+	return ic.ExecCommand(ctx, task, "/bin/sh", nil)
 }
 
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {

--- a/app/container/aws-fargate/provider.go
+++ b/app/container/aws-fargate/provider.go
@@ -100,6 +100,24 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 	return ic.ExecCommand(ctx, task, userConfig["cmd"])
 }
 
+func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
+	ic, err := p.identify(nsConfig, details)
+	if err != nil {
+		return err
+	}
+
+	task, _ := userConfig["task"].(string)
+	if task == "" {
+		if task, err = ic.GetRandomTask(); err != nil {
+			return err
+		} else if task == "" {
+			return fmt.Errorf("cannot exec command with no running tasks")
+		}
+	}
+
+	return ic.ExecCommand(ctx, task, "/bin/sh")
+}
+
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {
 	ic := &InfraConfig{}
 	retriever := outputs.Retriever{NsConfig: nsConfig}

--- a/app/provider.go
+++ b/app/provider.go
@@ -38,6 +38,9 @@ type Provider interface {
 	// This only makes sense for container-based providers
 	Exec(ctx context.Context, nsConfig api.Config, details Details, userConfig map[string]string) error
 
+	// Ssh allows a user to SSH into a running service
+	Ssh(ctx context.Context, nsConfig api.Config, details Details, userConfig map[string]any) error
+
 	// Status returns a high-level status report on the specified app env
 	Status(nsConfig api.Config, details Details) (StatusReport, error)
 

--- a/app/server/aws-ec2/infra_config.go
+++ b/app/server/aws-ec2/infra_config.go
@@ -17,9 +17,9 @@ func (c InfraConfig) Print(logger *log.Logger) {
 	logger.Printf("instance id: %q\n", c.Outputs.InstanceId)
 }
 
-func (c InfraConfig) ExecCommand(ctx context.Context, cmd string) error {
+func (c InfraConfig) ExecCommand(ctx context.Context, cmd string, parameters map[string][]string) error {
 	// TODO: Add support for cmd
 	region := c.Outputs.Region
 	awsConfig := nsaws.NewConfig(c.Outputs.Adminer, region)
-	return ssm.StartEc2Session(ctx, awsConfig, region, c.Outputs.InstanceId)
+	return ssm.StartEc2Session(ctx, awsConfig, region, c.Outputs.InstanceId, parameters)
 }

--- a/app/server/aws-ec2/provider.go
+++ b/app/server/aws-ec2/provider.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
 	"gopkg.in/nullstone-io/nullstone.v0/outputs"
 	"log"
 	"os"
@@ -48,7 +50,7 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 		return err
 	}
 
-	return ic.ExecCommand(ctx, userConfig["cmd"])
+	return ic.ExecCommand(ctx, userConfig["cmd"], nil)
 }
 
 func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
@@ -57,7 +59,14 @@ func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Deta
 		return err
 	}
 
-	return ic.ExecCommand(ctx, "/bin/sh")
+	var parameters map[string][]string
+	if val, ok := userConfig["forwards"].([]config.PortForward); ok {
+		if parameters, err = ssm.SessionParametersFromPortForwards(val); err != nil {
+			return err
+		}
+	}
+
+	return ic.ExecCommand(ctx, "/bin/sh", parameters)
 }
 
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {

--- a/app/server/aws-ec2/provider.go
+++ b/app/server/aws-ec2/provider.go
@@ -51,6 +51,15 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 	return ic.ExecCommand(ctx, userConfig["cmd"])
 }
 
+func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
+	ic, err := p.identify(nsConfig, details)
+	if err != nil {
+		return err
+	}
+
+	return ic.ExecCommand(ctx, "/bin/sh")
+}
+
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {
 	return app.StatusReport{}, fmt.Errorf("status is not supported for the aws-ec2 provider")
 }

--- a/app/serverless/aws-lambda/provider.go
+++ b/app/serverless/aws-lambda/provider.go
@@ -104,7 +104,11 @@ func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig ma
 }
 
 func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]string) error {
-	return fmt.Errorf("exec is not supported for the aws-lambda provider")
+	return fmt.Errorf("exec is not implemented for the aws-lambda provider yet")
+}
+
+func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
+	return fmt.Errorf("ssh is not supported for the aws-lambda provider")
 }
 
 func (p Provider) Status(nsConfig api.Config, details app.Details) (app.StatusReport, error) {

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -69,6 +69,10 @@ func (p Provider) Exec(ctx context.Context, nsConfig api.Config, details app.Det
 	return fmt.Errorf("exec is not supported for the aws-s3 provider")
 }
 
+func (p Provider) Ssh(ctx context.Context, nsConfig api.Config, details app.Details, userConfig map[string]any) error {
+	return fmt.Errorf("ssh is not supported for the aws-s3 provider")
+}
+
 func (p Provider) Deploy(nsConfig api.Config, details app.Details, userConfig map[string]string) error {
 	ic, err := p.identify(nsConfig, details)
 	if err != nil {

--- a/aws/ssm/ecs.go
+++ b/aws/ssm/ecs.go
@@ -8,7 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
-func StartEcsSession(ctx context.Context, config aws.Config, region, cluster, taskId, containerName, cmd string) error {
+func StartEcsSession(ctx context.Context, config aws.Config, region, cluster, taskId, containerName, cmd string, parameters map[string][]string) error {
+	docName := GetDocumentName(parameters)
+
 	ecsClient := ecs.NewFromConfig(config)
 	input := &ecs.ExecuteCommandInput{
 		Cluster:     aws.String(cluster),
@@ -23,7 +25,9 @@ func StartEcsSession(ctx context.Context, config aws.Config, region, cluster, ta
 	}
 
 	target := ssm.StartSessionInput{
-		Target: aws.String(fmt.Sprintf("ecs:%s_%s_%s", cluster, taskId, containerName)),
+		DocumentName: docName,
+		Target:       aws.String(fmt.Sprintf("ecs:%s_%s_%s", cluster, taskId, containerName)),
+		Parameters:   parameters,
 	}
 
 	er := ecs.NewDefaultEndpointResolver()

--- a/aws/ssm/get_document_name.go
+++ b/aws/ssm/get_document_name.go
@@ -1,0 +1,19 @@
+package ssm
+
+import "github.com/aws/aws-sdk-go-v2/aws"
+
+var (
+	DocNameStartSSH                = "AWS-StartSSHSession"
+	DocNamePortForward             = "AWS-StartPortForwardingSession"
+	DocNamePortForwardToRemoteHost = "AWS-StartPortForwardingSessionToRemoteHost"
+)
+
+func GetDocumentName(parameters map[string][]string) *string {
+	if _, forward := parameters["portNumber"]; forward {
+		if _, remote := parameters["host"]; remote {
+			return aws.String(DocNamePortForwardToRemoteHost)
+		}
+		return aws.String(DocNamePortForward)
+	}
+	return aws.String(DocNameStartSSH)
+}

--- a/aws/ssm/session_parameters.go
+++ b/aws/ssm/session_parameters.go
@@ -1,0 +1,24 @@
+package ssm
+
+import (
+	"fmt"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
+)
+
+func SessionParametersFromPortForwards(pfs []config.PortForward) (map[string][]string, error) {
+	switch len(pfs) {
+	case 0:
+		return nil, nil
+	case 1:
+		m := map[string][]string{
+			"localPort":  {pfs[0].LocalPort},
+			"portNumber": {pfs[0].RemotePort},
+		}
+		if pfs[0].RemoteHost != "" {
+			m["host"] = []string{pfs[0].RemoteHost}
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("AWS does not support more than one port forward.")
+	}
+}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"gopkg.in/nullstone-io/nullstone.v0/config"
 )
 
 var Ssh = func(providers app.Providers) *cli.Command {
@@ -27,6 +29,16 @@ var Ssh = func(providers app.Providers) *cli.Command {
 			userConfig := map[string]any{
 				"task": c.String("task"),
 			}
+
+			forwards := make([]config.PortForward, 0)
+			for _, arg := range c.StringSlice("forward") {
+				pf, err := config.ParsePortForward(arg)
+				if err != nil {
+					return fmt.Errorf("invalid format for --forward/-L: %w", err)
+				}
+				forwards = append(forwards, pf)
+			}
+			userConfig["forwards"] = forwards
 
 			return AppEnvAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
 				return provider.Ssh(ctx, cfg, details, userConfig)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
+)
+
+var Ssh = func(providers app.Providers) *cli.Command {
+	return &cli.Command{
+		Name:      "ssh",
+		Usage:     "SSH into a running service. Use to forward ports from remote service or hosts.",
+		UsageText: "nullstone ssh [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Flags: []cli.Flag{
+			StackFlag,
+			AppFlag,
+			EnvFlag,
+			TaskFlag,
+			&cli.StringSliceFlag{
+				Name:    "forward",
+				Aliases: []string{"L"},
+				Usage:   "Use this to forward ports from host to local machine. Format: <local-port>:[<remote-host>]:<remote-port>",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			userConfig := map[string]any{
+				"task": c.String("task"),
+			}
+
+			return AppEnvAction(c, providers, func(ctx context.Context, cfg api.Config, provider app.Provider, details app.Details) error {
+				return provider.Ssh(ctx, cfg, details, userConfig)
+			})
+		},
+	}
+}

--- a/config/port_forward.go
+++ b/config/port_forward.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ParsePortForward(arg string) (PortForward, error) {
+	tokens := strings.SplitN(arg, ":", 3)
+	switch len(tokens) {
+	case 2:
+		return PortForward{
+			LocalPort:  tokens[0],
+			RemoteHost: "",
+			RemotePort: tokens[1],
+		}, nil
+	case 3:
+		return PortForward{
+			LocalPort:  tokens[0],
+			RemoteHost: tokens[1],
+			RemotePort: tokens[2],
+		}, nil
+	default:
+		return PortForward{}, fmt.Errorf("expected <local-port>:[<remote-host>]:<remote-port>")
+	}
+}
+
+type PortForward struct {
+	LocalPort  string
+	RemoteHost string
+	RemotePort string
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/nullstone-io/nullstone.v0
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -103,7 +103,6 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbjdL7GzRt3F8NvfJ0=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -188,7 +187,6 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -908,7 +906,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
@@ -1188,7 +1185,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -80,6 +80,7 @@ func main() {
 			cmd.Logs(appProviders, logProviders),
 			cmd.Status(appProviders),
 			cmd.Exec(appProviders),
+			cmd.Ssh(appProviders),
 		},
 	}
 	sort.Sort(cli.FlagsByName(cliApp.Flags))


### PR DESCRIPTION
This adds a new command `nullstone ssh` which provides:
- SSH support for `aws-fargate` and `aws-ec2`.
- Port Forward support for `aws-ec2`.