### PR TITLE
Fixed artifact push to lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.61 (Jun 08, 2022)
+* Changed `aws/lambda` provider to upload artifacts with `Content-MD5` header to work for S3 Artifacts bucket that has object lock enabled.
+
 # 0.0.60 (Jun 07, 2022)
 * Changed `aws/s3` provider to invalidate **all** content when deploying new version.
 

--- a/app/serverless/aws-lambda/infra_config.go
+++ b/app/serverless/aws-lambda/infra_config.go
@@ -2,6 +2,9 @@ package aws_lambda
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -23,12 +26,24 @@ func (c InfraConfig) Print(logger *log.Logger) {
 	logger.Printf("artifacts bucket: %q\n", c.Outputs.ArtifactsBucketName)
 }
 
-func (c InfraConfig) UploadArtifact(ctx context.Context, content io.Reader, version string) error {
+func (c InfraConfig) UploadArtifact(ctx context.Context, content io.ReadSeeker, version string) error {
 	s3Client := s3.NewFromConfig(nsaws.NewConfig(c.Outputs.Deployer, c.Outputs.Region))
+
+	// Calculate MD5 of content and reset reader so it can transmit using s3.PutObject
+	md5Summer := md5.New()
+	if _, err := io.Copy(md5Summer, content); err != nil {
+		return fmt.Errorf("error calculating md5 hash: %w", err)
+	}
+	md5Sum := hex.EncodeToString(md5Summer.Sum(nil))
+	if _, err := content.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("error resetting uploaded content after calculating md5 hash")
+	}
+
 	_, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(c.Outputs.ArtifactsBucketName),
-		Key:    aws.String(c.Outputs.ArtifactsKey(version)),
-		Body:   content,
+		Bucket:     aws.String(c.Outputs.ArtifactsBucketName),
+		Key:        aws.String(c.Outputs.ArtifactsKey(version)),
+		Body:       content,
+		ContentMD5: aws.String(md5Sum),
 	})
 	return err
 }


### PR DESCRIPTION
https://app.ora.pm/p/280750?c=9138409

This calculates the md5 hash for the uploaded content and adds as header to `s3:PutObject`.
This is required when the s3 bucket has object lock enabled.