### PR TITLE
C931 contract

### DIFF
--- a/contracts/aws-fargate-service/outputs.go
+++ b/contracts/aws-fargate-service/outputs.go
@@ -14,7 +14,7 @@ type Outputs struct {
 	MainContainerName string          `ns:"main_container_name,optional"`
 	Deployer          aws.User        `ns:"deployer,optional"`
 
-	Cluster aws_fargate.Outputs `ns:",connectionType:cluster/aws-fargate"`
+	Cluster aws_fargate.Outputs `ns:",connectionType:cluster/aws-fargate,connectionContract=cluster/aws/ecs:fargate"`
 }
 
 func (o Outputs) GetDeployer() aws.User {

--- a/outputs/errors.go
+++ b/outputs/errors.go
@@ -16,12 +16,13 @@ func (e ErrInvalidContractField) Error() string {
 }
 
 type ErrMissingRequiredConnection struct {
-	ConnectionName string
-	ConnectionType string
+	ConnectionName     string
+	ConnectionType     string
+	ConnectionContract string
 }
 
 func (e ErrMissingRequiredConnection) Error() string {
-	return fmt.Sprintf("required connection missing (name=%s, type=%s)", e.ConnectionName, e.ConnectionType)
+	return fmt.Sprintf("required connection missing (name=%s, type=%s, contract=%s)", e.ConnectionName, e.ConnectionType, e.ConnectionContract)
 }
 
 type ErrMissingRequiredOutput struct {

--- a/outputs/field.go
+++ b/outputs/field.go
@@ -12,6 +12,7 @@ var (
 	StructTag               = "ns"
 	StructTagConnectionName = "connectionName"
 	StructTagConnectionType = "connectionType"
+	StructTagConnectionContract = "connectionContract"
 	StructTagOptional       = "optional"
 )
 
@@ -38,12 +39,13 @@ Notes:
   If you want to make a field/connection optional, add `ns:"output,optional"`
 */
 type Field struct {
-	Field          reflect.StructField
-	Tag            string
-	Name           string
-	ConnectionType string
-	ConnectionName string
-	Optional       bool
+	Field              reflect.StructField
+	Tag                string
+	Name               string
+	ConnectionType     string
+	ConnectionName     string
+	ConnectionContract string
+	Optional           bool
 }
 
 func (f Field) SafeSet(sourceObj interface{}, outputs types.Outputs) error {
@@ -113,6 +115,7 @@ func GetFields(typ reflect.Type) []Field {
 		field.Name = structured.Name
 		field.ConnectionName = structured.Options[StructTagConnectionName]
 		field.ConnectionType = structured.Options[StructTagConnectionType]
+		field.ConnectionContract = structured.Options[StructTagConnectionContract]
 		field.Optional = structured.HasOption(StructTagOptional)
 
 		fields = append(fields, field)

--- a/outputs/field_test.go
+++ b/outputs/field_test.go
@@ -15,6 +15,7 @@ func TestGetFields(t *testing.T) {
 		OptionalOutput string `ns:"optional_output,optional"`
 
 		Dependency DependencyOutputs `ns:",connectionType:some-dependency"`
+		Another    DependencyOutputs `ns:",connectionContract:cluster/aws/ecs:ec2"`
 	}
 	outputsType := reflect.TypeOf(Outputs{})
 
@@ -42,6 +43,15 @@ func TestGetFields(t *testing.T) {
 			ConnectionType: "some-dependency",
 			ConnectionName: "",
 			Optional:       false,
+		},
+		{
+			Field:              outputsType.Field(3),
+			Tag:                ",connectionContract:cluster/aws/ecs:ec2",
+			Name:               "",
+			ConnectionName:     "",
+			ConnectionType:     "",
+			ConnectionContract: "cluster/aws/ecs:ec2",
+			Optional:           false,
 		},
 	}
 

--- a/outputs/mock_ns.go
+++ b/outputs/mock_ns.go
@@ -13,10 +13,17 @@ import (
 func mockNs(workspaces []types.Workspace) (*httptest.Server, api.Config) {
 	mux := http.NewServeMux()
 	for _, workspace := range workspaces {
+		cur := workspace
 		endpoint := fmt.Sprintf("/orgs/%s/stacks/%d/blocks/%d/envs/%d",
-			workspace.OrgName, workspace.StackId, workspace.BlockId, workspace.EnvId)
+			cur.OrgName, cur.StackId, cur.BlockId, cur.EnvId)
 		mux.Handle(endpoint, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			raw, _ := json.Marshal(workspace)
+			raw, _ := json.Marshal(cur)
+			w.Write(raw)
+		}))
+		outputsEndpoint := fmt.Sprintf("/orgs/%s/stacks/%d/blocks/%d/envs/%d/outputs/latest",
+			cur.OrgName, cur.StackId, cur.BlockId, cur.EnvId)
+		mux.Handle(outputsEndpoint, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := json.Marshal(cur.LastFinishedRun.Apply.Outputs)
 			w.Write(raw)
 		}))
 	}

--- a/outputs/retriever.go
+++ b/outputs/retriever.go
@@ -110,7 +110,7 @@ func findConnection(source *types.Workspace, connectionName, connectionType, con
 	}
 	hasType := connectionType != ""
 	hasContract := connectionContract != ""
-	if connectionName == "" || (!hasType && !hasContract) {
+	if connectionName == "" && (!hasType && !hasContract) {
 		return nil, fmt.Errorf("cannot find connection if name or type/contract is not specified")
 	}
 	var desiredContract types.ModuleContractName


### PR DESCRIPTION
Added `connectionContract` struct tag to outputs retriever.
This allows us to use the new module taxonomy instead of module type when extracting outputs from modules.
This is necessary since module type is no longer available in certain scenarios.

I had to fix the outputs/retriever tests that have been failing for awhile.