### PR TITLE
Auto module version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.0.65 (Jul 11, 2022)
+# 0.0.65 (Jul 21, 2022)
 * Added application support for `app:container/aws/ecs:ec2`.
 * Fixed `blocks new` when the selected module is an application module.
+* Added `--version=auto` to `modules publish` that uses latest version and bumps the patch component.
 
 # 0.0.64 (Jul 01, 2022)
 * Fixed selection of category when running `modules generate`.

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -152,7 +152,7 @@ var ModulesPackage = &cli.Command{
 	Name:      "package",
 	Usage:     "Package a module",
 	UsageText: "nullstone modules package",
-	Flags: []cli.Flag{
+	Flags:     []cli.Flag{
 		// TODO: We currently support *.tf, .*tf.tmpl patterns; add support for packaging additional files into the module package
 	},
 	Action: func(c *cli.Context) error {

--- a/modules/auto_version.go
+++ b/modules/auto_version.go
@@ -1,0 +1,40 @@
+package modules
+
+import (
+	"fmt"
+	"golang.org/x/mod/semver"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/find"
+	"strconv"
+	"strings"
+)
+
+// AutoVersion bumps the patch in major.minor.patch from the latest module version
+func AutoVersion(cfg api.Config, manifest *Manifest) (string, error) {
+	latestVersion, err := find.ModuleVersion(cfg, fmt.Sprintf("%s/%s", manifest.OrgName, manifest.Name), "latest")
+	if err != nil {
+		return "", fmt.Errorf("error retrieving latest version: %w", err)
+	}
+	return BumpPatch(latestVersion.Version), nil
+}
+
+func BumpPatch(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	curPatch := getPatch(version)
+	return fmt.Sprintf("%s.%d", semver.MajorMinor(version), curPatch+1)
+}
+
+func getPatch(version string) int {
+	tokens := strings.SplitN(semver.Canonical(version), ".", 3)
+	if len(tokens) < 3 {
+		return 0
+	}
+	rawPatch := strings.TrimSuffix(tokens[2], semver.Prerelease(version))
+	patch, err := strconv.Atoi(rawPatch)
+	if err != nil {
+		return 0
+	}
+	return patch
+}

--- a/modules/auto_version_test.go
+++ b/modules/auto_version_test.go
@@ -1,0 +1,48 @@
+package modules
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestBumpPatch(t *testing.T) {
+	tests := []struct {
+		latest string
+		want   string
+	}{
+		{
+			latest: "1",
+			want:   "1.0.1",
+		},
+		{
+			latest: "1.0",
+			want:   "1.0.1",
+		},
+		{
+			latest: "1.0.0",
+			want:   "1.0.1",
+		},
+		{
+			latest: "1.2.0",
+			want:   "1.2.1",
+		},
+		{
+			latest: "1.2.0-pre",
+			want:   "1.2.1",
+		},
+		{
+			latest: "1.2.0-pre+build",
+			want:   "1.2.1",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := BumpPatch(test.latest)
+			got = strings.TrimPrefix(got, "v")
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/outputs/field.go
+++ b/outputs/field.go
@@ -9,11 +9,11 @@ import (
 )
 
 var (
-	StructTag               = "ns"
-	StructTagConnectionName = "connectionName"
-	StructTagConnectionType = "connectionType"
+	StructTag                   = "ns"
+	StructTagConnectionName     = "connectionName"
+	StructTagConnectionType     = "connectionType"
 	StructTagConnectionContract = "connectionContract"
-	StructTagOptional       = "optional"
+	StructTagOptional           = "optional"
 )
 
 /*

--- a/outputs/retriever_test.go
+++ b/outputs/retriever_test.go
@@ -112,7 +112,7 @@ func TestRetriever_Retrieve(t *testing.T) {
 						Reference: &types.ConnectionTarget{
 							StackId: 1,
 							BlockId: 7,
-							EnvId: nil,
+							EnvId:   nil,
 						},
 						Unused: false,
 					},
@@ -145,7 +145,6 @@ func TestRetriever_Retrieve(t *testing.T) {
 				"key3": "value3",
 			},
 		}
-
 
 		retriever := Retriever{NsConfig: nsConfig}
 		var got MockFlatOutputs


### PR DESCRIPTION
Added support for `--version=auto` in `modules publish` command.
This uses the latest version and bumps the patch.