### PR TITLE
C982 Emit non-zero exit code and error message when run fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.72 (Aug 02, 2022)
+* When running a `plan`/`apply` with `--wait`:
+  * A failed plan causes the CLI to exit with non-zero code.
+  * A failed plan causes the CLI to print the error message.
+
 # 0.0.71 (Aug 02, 2022)
 * Fixed comparison of module versions when using `next-build` and `next-patch`.
 


### PR DESCRIPTION
This does the following to improve plan/apply command:
1. When using `--wait` with `plan`/`apply`, a failed run will cause the command to fail with a non-zero exit code.
2. An error message emits on failed runs pulled from `run.StatusMessage`.