### PR TITLE
Add README to package, print error when unable to init terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.0.78 (Unreleased)
 * Fixed emitted browser URL when a plan needs approval.
+* Changed `nullstone modules publish` to include `README.md` in the package.
+* Changed `nullstone workspaces select` to print specific error message if unable to initialize Terraform.
 
 # 0.0.77 (Aug 13, 2022)
 * Changed deployments to run on the Nullstone servers and stream the logs through the CLI. 

--- a/modules/package.go
+++ b/modules/package.go
@@ -9,6 +9,7 @@ var (
 	moduleFilePatterns = []string{
 		"*.tf",
 		"*.tf.tmpl",
+		"README.md",
 	}
 	excludes = map[string]struct{}{
 		"__backend__.tf": struct{}{},

--- a/workspaces/select.go
+++ b/workspaces/select.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"gopkg.in/nullstone-io/nullstone.v0/git"
+	"log"
 	"path"
 	"strings"
 )
@@ -60,6 +61,7 @@ func Select(ctx context.Context, cfg api.Config, workspace Manifest, runConfig t
 		fallbackMessage := `Unable to initialize terraform.
 Reset .terraform/ directory and run 'terraform init'.`
 		fmt.Println(fallbackMessage)
+		log.Println(err)
 	}
 	return nil
 }


### PR DESCRIPTION
* Changed `nullstone modules publish` to include `README.md` in the package.
* Changed `nullstone workspaces select` to print specific error message if unable to initialize Terraform.