### PR TITLE
Added --include flag to modules publish|package commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.79 (Unreleased)
 * Fixed panic when running `nullstone status` on apps that do not have status support in the CLI.
+* Added `--include` flag to package additional files when running `nullstone modules publish` or `nullstone modules package`.
 
 # 0.0.78 (Aug 31, 2022)
 * Fixed emitted browser URL when a plan needs approval.

--- a/modules/package.go
+++ b/modules/package.go
@@ -12,11 +12,11 @@ var (
 		"README.md",
 	}
 	excludes = map[string]struct{}{
-		"__backend__.tf": struct{}{},
+		"__backend__.tf": {},
 	}
 )
 
-func Package(manifest *Manifest, version string) (string, error) {
+func Package(manifest *Manifest, version string, addlFiles []string) (string, error) {
 	excludeFn := func(entry artifacts.GlobEntry) bool {
 		_, ok := excludes[entry.Path]
 		return ok
@@ -26,5 +26,6 @@ func Package(manifest *Manifest, version string) (string, error) {
 	if version != "" {
 		tarballFilename = fmt.Sprintf("%s-%s.tar.gz", manifest.Name, version)
 	}
-	return tarballFilename, artifacts.PackageModule(".", tarballFilename, moduleFilePatterns, excludeFn)
+	allPatterns := append(moduleFilePatterns, addlFiles...)
+	return tarballFilename, artifacts.PackageModule(".", tarballFilename, allPatterns, excludeFn)
 }


### PR DESCRIPTION
The https://github.com/nullstone-modules/pg-db-admin module is broken after switching from curl to the nullstone CLI to perform module publish. This is because `nullstone modules publish` does not include the necessary `files/pg-db-admin.zip` in the package when publishing.

This adds an `--include` flag so that the above module can issue the following when publishing:
```
nullstone modules publish --version=<version> --include=files/pg-db-admin.zip
```