### PR TITLE
No longer emitting "context cancelled" error when user cancels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.81 (Unreleased)
+* CLI no longer prints `context canceled` when a user cancels a command. 
+
 # 0.0.80 (Sep 21, 2022)
 * Updated `outputs` command and deployments to use a new endpoint that references outputs from the state backend. 
 

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	allApp "github.com/nullstone-io/deployment-sdk/app/all"
 	"github.com/urfave/cli/v2"
@@ -67,6 +69,9 @@ func main() {
 
 	err := cliApp.Run(os.Args)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(0)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	} else {


### PR DESCRIPTION
* CLI no longer prints `context canceled` when a user cancels a command.