### PR TITLE
C897 cli docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME := nullstone
 
-.PHONY: setup test
+.PHONY: setup test docs
 
 .DEFAULT_GOAL: default
 
@@ -16,3 +16,6 @@ build:
 test:
 	go fmt ./...
 	gotestsum ./...
+
+docs:
+	go run ./docs/main.go

--- a/app/build.go
+++ b/app/build.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	allApp "github.com/nullstone-io/deployment-sdk/app/all"
+	"github.com/urfave/cli/v2"
+	allAdmin "gopkg.in/nullstone-io/nullstone.v0/admin/all"
+	"gopkg.in/nullstone-io/nullstone.v0/cmd"
+	"sort"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
+func Build() *cli.App {
+	appProviders := allApp.Providers
+	adminProviders := allAdmin.Providers
+
+	cliApp := &cli.App{
+		Version:              version,
+		EnableBashCompletion: true,
+		Metadata: map[string]interface{}{
+			"commit":  commit,
+			"date":    date,
+			"builtBy": builtBy,
+		},
+		Flags: []cli.Flag{
+			cmd.ProfileFlag,
+			cmd.OrgFlag,
+		},
+		Commands: []*cli.Command{
+			{
+				Name: "version",
+				Action: func(c *cli.Context) error {
+					cli.ShowVersion(c)
+					return nil
+				},
+			},
+			cmd.Configure,
+			cmd.SetOrg,
+			cmd.Stacks,
+			cmd.Envs,
+			cmd.Apps,
+			cmd.Blocks,
+			cmd.Modules,
+			cmd.Workspaces,
+			cmd.Up(),
+			cmd.Plan(),
+			cmd.Apply(),
+			cmd.Outputs(),
+			cmd.Push(appProviders),
+			cmd.Deploy(appProviders),
+			cmd.Launch(appProviders),
+			cmd.Logs(adminProviders),
+			cmd.Status(adminProviders),
+			cmd.Exec(adminProviders),
+			cmd.Ssh(adminProviders),
+		},
+	}
+	sort.Sort(cli.FlagsByName(cliApp.Flags))
+	sort.Sort(cli.CommandsByName(cliApp.Commands))
+
+	return cliApp
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,9 +13,10 @@ import (
 
 var Apply = func() *cli.Command {
 	return &cli.Command{
-		Name:      "apply",
-		Usage:     "Runs an apply with optional auto-approval",
-		UsageText: "nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		Name:        "apply",
+		Description: "Runs a Terraform apply on the given block and environment. This is useful for making ad-hoc changes to your infrastructure.\nBe sure to run `nullstone plan` first to see what changes will be made.",
+		Usage:       "Runs an apply with optional auto-approval",
+		UsageText:   "nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,
@@ -23,19 +24,19 @@ var Apply = func() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "wait",
 				Aliases: []string{"w"},
-				Usage:   "Stream the Terraform logs while waiting for Nullstone to run the apply.",
+				Usage:   "Wait for the apply to complete and stream the Terraform logs to the console.",
 			},
 			&cli.BoolFlag{
 				Name:  "auto-approve",
-				Usage: "Auto-approve any changes made in Terraform",
+				Usage: "Skip any approvals and apply the changes immediately. This requires proper permissions in the stack.",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
-				Usage: "Set variable values when issuing `apply`",
+				Usage: "Set variables values for the apply. This can be used to override variables defined in the module.",
 			},
 			&cli.StringFlag{
 				Name:  "module-version",
-				Usage: "Use a specific module version to run the apply.",
+				Usage: "The version of the module to apply.",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,10 +13,12 @@ import (
 
 var Apply = func() *cli.Command {
 	return &cli.Command{
-		Name:        "apply",
-		Description: "Runs a Terraform apply on the given block and environment. This is useful for making ad-hoc changes to your infrastructure.\nBe sure to run `nullstone plan` first to see what changes will be made.",
-		Usage:       "Runs an apply with optional auto-approval",
-		UsageText:   "nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		Name: "apply",
+		Description: "Runs a Terraform apply on the given block and environment. This is useful for making ad-hoc changes to your infrastructure.\n" +
+			"This plan will be executed by the Nullstone system. In order to run a plan locally, check out the `nullstone workspaces select` command.\n" +
+			"Be sure to run `nullstone plan` first to see what changes will be made.",
+		Usage:     "Runs an apply with optional auto-approval",
+		UsageText: "nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -19,13 +19,15 @@ var Apps = &cli.Command{
 }
 
 var AppsList = &cli.Command{
-	Name:      "list",
-	Usage:     "List applications",
-	UsageText: "nullstone apps list",
+	Name:        "list",
+	Description: "Shows a list of the applications that you have access to. Set the `--detail` flag to show more details about each application.",
+	Usage:       "List applications",
+	UsageText:   "nullstone apps list",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "detail",
 			Aliases: []string{"d"},
+			Usage:   "Use this flag to show the details for each application",
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -22,14 +22,16 @@ var Blocks = &cli.Command{
 }
 
 var BlocksList = &cli.Command{
-	Name:      "list",
-	Usage:     "List blocks",
-	UsageText: "nullstone blocks list --stack=<stack>",
+	Name:        "list",
+	Description: "Shows a list of the blocks for the given stack. Set the `--detail` flag to show more details about each block.",
+	Usage:       "List blocks",
+	UsageText:   "nullstone blocks list --stack=<stack>",
 	Flags: []cli.Flag{
 		StackRequiredFlag,
 		&cli.BoolFlag{
 			Name:    "detail",
 			Aliases: []string{"d"},
+			Usage:   "Use this flag to show more details about each block",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -74,14 +76,16 @@ var BlocksList = &cli.Command{
 }
 
 var BlocksNew = &cli.Command{
-	Name:      "new",
-	Usage:     "Create block",
-	UsageText: "nullstone blocks new --name=<name> --stack=<stack> --module=<module> [--connection=<connection>...]",
+	Name:        "new",
+	Description: "Creates a new block with the given name and module. If the module has any connections, you can specify them using the `--connection` parameter.",
+	Usage:       "Create block",
+	UsageText:   "nullstone blocks new --name=<name> --stack=<stack> --module=<module> [--connection=<connection>...]",
 	Flags: []cli.Flag{
 		StackRequiredFlag,
 		&cli.StringFlag{
 			Name:     "name",
 			Required: true,
+			Usage:    "Provide a name for this new block",
 		},
 		&cli.StringFlag{
 			Name:     "module",
@@ -90,7 +94,7 @@ var BlocksNew = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "connection",
-			Usage: "Map the connection name on the module to the block name in the stack. Example: --connection network=network0",
+			Usage: "Specify any connections that this block will have to other blocks. Use the connection name as the key, and the connected block name as the value. Example: --connection network=network0",
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -14,17 +14,20 @@ var (
 	AddressFlag = &cli.StringFlag{
 		Name:  "address",
 		Value: api.DefaultAddress,
-		Usage: "Nullstone API Address",
+		Usage: "Specify the url for the Nullstone API.",
 	}
 	ApiKeyFlag = &cli.StringFlag{
 		Name:  "api-key",
 		Value: "",
-		Usage: "Nullstone API Key",
+		Usage: "Configure your personal API key that will be used to authenticate with the Nullstone API. You can generate an API key from your profile page.",
 	}
 )
 
 var Configure = &cli.Command{
-	Name: "configure",
+	Name:        "configure",
+	Description: "Establishes a profile and configures authentication for the CLI to use.",
+	Usage:       "Configure the nullstone CLI",
+	UsageText:   "nullstone configure --api-key=<api-key>",
 	Flags: []cli.Flag{
 		AddressFlag,
 		ApiKeyFlag,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -14,9 +14,10 @@ import (
 
 var Deploy = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "deploy",
-		Usage:     "Deploy application",
-		UsageText: "nullstone deploy [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Name:        "deploy",
+		Description: "Deploy a new version of your code for this application. This command works in tandem with the `nullstone push` command. This command deploys the artifacts that were uploaded during the `push` command.",
+		Usage:       "Deploy application",
+		UsageText:   "nullstone deploy [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,
@@ -25,6 +26,7 @@ var Deploy = func(providers app.Providers) *cli.Command {
 			&cli.BoolFlag{
 				Name:    "wait",
 				Aliases: []string{"w"},
+				Usage:   "Wait for the deploy to complete and stream the logs to the console.",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -28,14 +28,16 @@ var Envs = &cli.Command{
 }
 
 var EnvsList = &cli.Command{
-	Name:      "list",
-	Usage:     "List environments",
-	UsageText: "nullstone envs list --stack=<stack-name>",
+	Name:        "list",
+	Description: "Shows a list of the environments for the given stack. Set the `--detail` flag to show more details about each environment.",
+	Usage:       "List environments",
+	UsageText:   "nullstone envs list --stack=<stack-name>",
 	Flags: []cli.Flag{
 		StackRequiredFlag,
 		&cli.BoolFlag{
 			Name:    "detail",
 			Aliases: []string{"d"},
+			Usage:   "Use this flag to show more details about each environment",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -88,15 +90,30 @@ var EnvsList = &cli.Command{
 }
 
 var EnvsNew = &cli.Command{
-	Name:      "new",
-	Usage:     "Create new environment",
-	UsageText: "nullstone envs new --name=<name> --stack=<stack> --provider=<provider>",
+	Name:        "new",
+	Description: "Creates a new environment in the given stack. The environment will be created as the last environment in the pipeline. Specify the provider, region, and zone to determine where infrastructure will be provisioned for this environment.",
+	Usage:       "Create new environment",
+	UsageText:   "nullstone envs new --name=<name> --stack=<stack> --provider=<provider>",
 	Flags: []cli.Flag{
-		&cli.StringFlag{Name: "name", Required: true},
+		&cli.StringFlag{
+			Name:     "name",
+			Usage:    "Provide a name for this new environment",
+			Required: true,
+		},
 		StackFlag,
-		&cli.StringFlag{Name: "provider", Required: true},
-		&cli.StringFlag{Name: "region"},
-		&cli.StringFlag{Name: "zone"},
+		&cli.StringFlag{
+			Name:     "provider",
+			Usage:    "Provide the name of the provider to use for this environment",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:  "region",
+			Usage: fmt.Sprintf("Select which region to launch infrastructure for this environment. Defaults to %s for AWS and %s for GCP.", awsDefaultRegion, gcpDefaultRegion),
+		},
+		&cli.StringFlag{
+			Name:  "zone",
+			Usage: fmt.Sprintf("For GCP, select the zone to launch infrastructure for this environment. Defaults to %s", gcpDefaultZone),
+		},
 	},
 	Action: func(c *cli.Context) error {
 		return ProfileAction(c, func(cfg api.Config) error {

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -103,7 +103,7 @@ var EnvsNew = &cli.Command{
 		StackFlag,
 		&cli.StringFlag{
 			Name:     "provider",
-			Usage:    "Provide the name of the provider to use for this environment",
+			Usage:    "Select the name of the provider to use for this environment",
 			Required: true,
 		},
 		&cli.StringFlag{

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,9 +11,10 @@ import (
 
 var Exec = func(providers admin.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "exec",
-		Usage:     "Execute command on running service. Defaults command to '/bin/sh' which acts as opening a shell to the running container.",
-		UsageText: "nullstone exec [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options] [command]",
+		Name:        "exec",
+		Description: "Executes a command on a container or the virtual machine for the given application. Defaults command to '/bin/sh' which acts as opening a shell to the running container or virtual machine.",
+		Usage:       "Execute a command on running service",
+		UsageText:   "nullstone exec [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options] [command]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,

--- a/cmd/flag_app.go
+++ b/cmd/flag_app.go
@@ -4,7 +4,7 @@ import "github.com/urfave/cli/v2"
 
 var AppFlag = &cli.StringFlag{
 	Name:    "app",
-	Usage:   "Set the application name.",
+	Usage:   "Name of the app to use for this operation",
 	EnvVars: []string{"NULLSTONE_APP"},
 	// TODO: Set to required once we fully deprecate parsing app as first command arg
 	// Required: true,

--- a/cmd/flag_app_source.go
+++ b/cmd/flag_app_source.go
@@ -4,8 +4,8 @@ import "github.com/urfave/cli/v2"
 
 var AppSourceFlag = &cli.StringFlag{
 	Name: "source",
-	Usage: `The source artifact to push.
-       app/container: This is the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
-       app/serverless: This is a .zip archive to push.`,
+	Usage: `The source artifact to push that contains your application's build.
+		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
+		For a serverless zip application, specify the .zip archive to push.`,
 	Required: true,
 }

--- a/cmd/flag_app_source.go
+++ b/cmd/flag_app_source.go
@@ -6,6 +6,7 @@ var AppSourceFlag = &cli.StringFlag{
 	Name: "source",
 	Usage: `The source artifact to push that contains your application's build.
 		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.
-		For a serverless zip application, specify the .zip archive to push.`,
+		For a serverless zip application, specify the .zip archive to push.
+		For a static site, specify the directory to push.`,
 	Required: true,
 }

--- a/cmd/flag_app_version.go
+++ b/cmd/flag_app_version.go
@@ -4,10 +4,8 @@ import "github.com/urfave/cli/v2"
 
 var AppVersionFlag = &cli.StringFlag{
 	Name: "version",
-	Usage: `Push/Deploy the artifact with this version.
-       If not specified, will retrieve short sha from your latest commit.
-       app/container: If specified, will push the docker image with version as the image tag. Otherwise, uses source tag.
-       app/serverless: This is required to upload the artifact.`,
+	Usage: `Provide a label for your deployment.
+		If not provided, it will default to the commit sha of the repo for the current directory.`,
 }
 
 func DetectAppVersion(c *cli.Context) string {

--- a/cmd/flag_block.go
+++ b/cmd/flag_block.go
@@ -4,7 +4,7 @@ import "github.com/urfave/cli/v2"
 
 var BlockFlag = &cli.StringFlag{
 	Name:     "block",
-	Usage:    "Set the block name.",
+	Usage:    "Name of the block to use for this operation",
 	EnvVars:  []string{"NULLSTONE_BLOCK", "NULLSTONE_APP"},
 	Required: true,
 }

--- a/cmd/flag_env.go
+++ b/cmd/flag_env.go
@@ -4,14 +4,14 @@ import "github.com/urfave/cli/v2"
 
 var EnvFlag = &cli.StringFlag{
 	Name:     "env",
-	Usage:    `Set the environment name.`,
+	Usage:    `Name of the environment to use for this operation`,
 	EnvVars:  []string{"NULLSTONE_ENV"},
 	Required: true,
 }
 
 var OldEnvFlag = &cli.StringFlag{
 	Name:    "env",
-	Usage:   `Set the environment name.`,
+	Usage:   `Name of the environment to use for this operation`,
 	EnvVars: []string{"NULLSTONE_ENV"},
 	// TODO: Set to required once we fully deprecate parsing app as first command arg
 	// Required: true,
@@ -19,7 +19,7 @@ var OldEnvFlag = &cli.StringFlag{
 
 var EnvOptionalFlag = &cli.StringFlag{
 	Name:     "env",
-	Usage:    `Set the environment name.`,
+	Usage:    `Name of the environment to use for this operation`,
 	EnvVars:  []string{"NULLSTONE_ENV"},
 	Required: false,
 }

--- a/cmd/flag_org.go
+++ b/cmd/flag_org.go
@@ -19,7 +19,7 @@ var (
 var OrgFlag = &cli.StringFlag{
 	Name:    "org",
 	EnvVars: []string{"NULLSTONE_ORG"},
-	Usage:   `Nullstone organization name used to contextualize API calls. If this flag is not specified, the nullstone CLI will use ~/.nullstone/<profile>/org file.`,
+	Usage:   `Nullstone organization name to use for this operation. If this flag is not specified, the nullstone CLI will use ~/.nullstone/<profile>/org file.`,
 }
 
 func GetOrg(c *cli.Context, profile config.Profile) string {

--- a/cmd/flag_profile.go
+++ b/cmd/flag_profile.go
@@ -6,7 +6,7 @@ var ProfileFlag = &cli.StringFlag{
 	Name:    "profile",
 	EnvVars: []string{"NULLSTONE_PROFILE"},
 	Value:   "default",
-	Usage:   "Name of profile",
+	Usage:   "Name of the profile to use for the operation",
 }
 
 func GetProfile(c *cli.Context) string {

--- a/cmd/flag_stack.go
+++ b/cmd/flag_stack.go
@@ -10,7 +10,7 @@ var StackFlag = &cli.StringFlag{
 
 var StackRequiredFlag = &cli.StringFlag{
 	Name:     "stack",
-	Usage:    "Set the stack to use for this operation",
+	Usage:    "Name of the stack to use for this operation",
 	EnvVars:  []string{"NULLSTONE_STACK"},
 	Required: true,
 }

--- a/cmd/flag_stack.go
+++ b/cmd/flag_stack.go
@@ -3,16 +3,14 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var StackFlag = &cli.StringFlag{
-	Name: "stack",
-	Usage: `Set the stack name that owns the app/block.
-       This is only required if multiple apps/blocks have the same name.`,
+	Name:    "stack",
+	Usage:   "Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name.",
 	EnvVars: []string{"NULLSTONE_STACK"},
 }
 
 var StackRequiredFlag = &cli.StringFlag{
-	Name: "stack",
-	Usage: `Set the stack name that owns the app/block.
-       This is only required if multiple apps/blocks have the same name.`,
+	Name:     "stack",
+	Usage:    "Set the stack to use for this operation",
 	EnvVars:  []string{"NULLSTONE_STACK"},
 	Required: true,
 }

--- a/cmd/flag_task.go
+++ b/cmd/flag_task.go
@@ -4,8 +4,8 @@ import "github.com/urfave/cli/v2"
 
 var TaskFlag = &cli.StringFlag{
 	Name: "task",
-	Usage: `Optionally, specify the task/replica to execute the command against.
-       If not specified, this will connect to a random task/replica.
-       If using Kubernetes, this will select which replica of the pod to connect.
-       If using ECS, this will select which task of the service to connect.`,
+	Usage: `Select a specific task/replica to execute the command against.
+		This is optional and by default will connect to a random task/replica.
+       	If using Kubernetes, this will select which replica of the pod to connect.
+       	If using ECS, this will select which task of the service to connect.`,
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -13,7 +13,9 @@ import (
 // Launch command performs push, deploy, and logs
 var Launch = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "launch",
+		Name: "launch",
+		Description: "This command will first upload (push) an artifact containing the source for your application. Then it will deploy it to the given environment and tail the logs for the deployment." +
+			"This command is the same as running `nullstone push` followed by `nullstone deploy -w`.",
 		Usage:     "Launch application (push + deploy + wait-healthy)",
 		UsageText: "nullstone launch [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -13,9 +13,10 @@ import (
 
 var Logs = func(providers admin.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "logs",
-		Usage:     "Emit application logs",
-		UsageText: "nullstone logs [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Name:        "logs",
+		Description: "Streams an application's logs to the console for the given environment. Use the start-time `-s` and end-time `-e` flags to only show logs for a given time period. Use the tail flag `-t` to stream the logs in real time.",
+		Usage:       "Emit application logs",
+		UsageText:   "nullstone logs [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,
@@ -43,7 +44,7 @@ var Logs = func(providers admin.Providers) *cli.Command {
 				Name:        "interval",
 				DefaultText: "1s",
 				Usage: `Set --interval to a golang duration to control how often to pull new log events.
-       This will do nothing unless --tail is set.
+       This will do nothing unless --tail is set. The default is 1 second.
       `,
 			},
 			&cli.BoolFlag{
@@ -51,7 +52,7 @@ var Logs = func(providers admin.Providers) *cli.Command {
 				Aliases: []string{"t"},
 				Usage: `Set tail to watch log events and emit as they are reported.
        Use --interval to control how often to query log events.
-       This is off by default, command will exit as soon as current log events are emitted.`,
+       This is off by default. Unless this option is provided, this command will exit as soon as current log events are emitted.`,
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -44,7 +44,7 @@ var Logs = func(providers admin.Providers) *cli.Command {
 				Name:        "interval",
 				DefaultText: "1s",
 				Usage: `Set --interval to a golang duration to control how often to pull new log events.
-       This will do nothing unless --tail is set. The default is 1 second.
+       This will do nothing unless --tail is set. The default is '1s' (1 second).
       `,
 			},
 			&cli.BoolFlag{

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -103,7 +103,7 @@ var ModulesRegister = &cli.Command{
 
 var ModulesPublish = &cli.Command{
 	Name:        "publish",
-	Description: "Publishes a new version for a module in the Nullstone registry. Provide a specific version semver using the `--version` parameter.",
+	Description: "Publishes a new version for a module in the Nullstone registry. Provide a specific semver version using the `--version` parameter.",
 	Usage:       "Package and publish new version of a module",
 	UsageText:   "nullstone modules publish --version=<version>",
 	Flags: []cli.Flag{

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -15,9 +15,9 @@ var (
 	moduleManifestFilename = path.Join(".nullstone", "module.yml")
 	includeFlag            = &cli.StringSliceFlag{
 		Name: "include",
-		Usage: `Specify additional file patterns to package.
-By default, this command includes *.tf, *.tf.tmpl, and README.md.
-Use this flag to package additional modules and files needed for applies.
+		Usage: `Specify additional file patterns to package. 
+By default, this command includes *.tf, *.tf.tmpl, and 'README.md'. 
+Use this flag to package additional modules and files needed for applies. 
 This supports file globbing detailed at https://pkg.go.dev/path/filepath#Glob`,
 	}
 )
@@ -35,11 +35,17 @@ var Modules = &cli.Command{
 }
 
 var ModulesGenerate = &cli.Command{
-	Name:      "generate",
+	Name: "generate",
+	Description: "Generates a nullstone manifest file for your module in the current directory. " +
+		"You will be asked a series of questions in order to collect the information needed to describe a Nullstone module. " +
+		"Optionally, you can also register the module in the Nullstone registry by passing the `--register` flag.",
 	Usage:     "Generate new module manifest (and optionally register)",
 	UsageText: "nullstone modules generate [--register]",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "register"},
+		&cli.BoolFlag{
+			Name:  "register",
+			Usage: "Register the module in the Nullstone registry after generating the manifest file.",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		return ProfileAction(c, func(cfg api.Config) error {
@@ -72,11 +78,12 @@ var ModulesGenerate = &cli.Command{
 }
 
 var ModulesRegister = &cli.Command{
-	Name:      "register",
-	Usage:     "Register module from .nullstone/module.yml",
-	UsageText: "nullstone modules register",
-	Flags:     []cli.Flag{},
-	Aliases:   []string{"new"},
+	Name:        "register",
+	Description: "Registers a module in the Nullstone registry. The information in .nullstone/module.yml will be used as the details for the new module.",
+	Usage:       "Register module from .nullstone/module.yml",
+	UsageText:   "nullstone modules register",
+	Flags:       []cli.Flag{},
+	Aliases:     []string{"new"},
 	Action: func(c *cli.Context) error {
 		return ProfileAction(c, func(cfg api.Config) error {
 			manifest, err := modules.ManifestFromFile(moduleManifestFilename)
@@ -95,9 +102,10 @@ var ModulesRegister = &cli.Command{
 }
 
 var ModulesPublish = &cli.Command{
-	Name:      "publish",
-	Usage:     "Package and publish new version of a module",
-	UsageText: "nullstone modules publish --version=<version>",
+	Name:        "publish",
+	Description: "Publishes a new version for a module in the Nullstone registry. Provide a specific version semver using the `--version` parameter.",
+	Usage:       "Package and publish new version of a module",
+	UsageText:   "nullstone modules publish --version=<version>",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "version",
@@ -175,9 +183,10 @@ var ModulesPublish = &cli.Command{
 }
 
 var ModulesPackage = &cli.Command{
-	Name:      "package",
-	Usage:     "Package a module",
-	UsageText: "nullstone modules package",
+	Name:        "package",
+	Description: "Package all the module contents for a Nullstone module into a tarball but do not publish to the registry.",
+	Usage:       "Package a module",
+	UsageText:   "nullstone modules package",
 	Flags: []cli.Flag{
 		includeFlag,
 	},

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -13,7 +13,7 @@ import (
 var Outputs = func() *cli.Command {
 	return &cli.Command{
 		Name:        "outputs",
-		Description: "Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. For less information in an easier to read format, use the `--plain` flag.",
+		Description: "Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. You must have proper permissions in order to use the `--sensitive` flag. For less information in an easier to read format, use the `--plain` flag.",
 		Usage:       "Retrieve outputs",
 		UsageText:   "nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -12,18 +12,21 @@ import (
 // Outputs command retrieves outputs from a workspace (block+env)
 var Outputs = func() *cli.Command {
 	return &cli.Command{
-		Name:      "outputs",
-		Usage:     "Retrieve outputs",
-		UsageText: "nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		Name:        "outputs",
+		Description: "Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. For less information in an easier to read format, use the `--plain` flag.",
+		Usage:       "Retrieve outputs",
+		UsageText:   "nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,
 			EnvFlag,
 			&cli.BoolFlag{
-				Name: "sensitive",
+				Name:  "sensitive",
+				Usage: "Include sensitive outputs in the results",
 			},
 			&cli.BoolFlag{
-				Name: "plain",
+				Name:  "plain",
+				Usage: "Print less information about the outputs in a more readable format",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -24,7 +24,7 @@ var Plan = func() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "wait",
 				Aliases: []string{"w"},
-				Usage:   "Wait for the apply to complete and stream the Terraform logs to the console.",
+				Usage:   "Wait for the plan to complete and stream the Terraform logs to the console.",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -13,9 +13,10 @@ import (
 
 var Plan = func() *cli.Command {
 	return &cli.Command{
-		Name:      "plan",
-		Usage:     "Runs a plan with a disapproval",
-		UsageText: "nullstone plan [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		Name:        "plan",
+		Description: "Run a plan for a given block and environment. This will automatically disapprove the plan and is useful for testing what a plan will do.",
+		Usage:       "Runs a plan with a disapproval",
+		UsageText:   "nullstone plan [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,
@@ -23,15 +24,15 @@ var Plan = func() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "wait",
 				Aliases: []string{"w"},
-				Usage:   "Stream the Terraform logs while waiting for Nullstone to run the plan.",
+				Usage:   "Wait for the apply to complete and stream the Terraform logs to the console.",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
-				Usage: "Set variable values when issuing `plan`",
+				Usage: "Set variables values for the plan. This can be used to override variables defined in the module.",
 			},
 			&cli.StringFlag{
 				Name:  "module-version",
-				Usage: "Use a specific module version to run the plan.",
+				Usage: "Run a plan with a specific version of the module.",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -13,7 +13,7 @@ import (
 var Push = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
 		Name:        "push",
-		Description: "Upload (push) an artifact containing the source for your application. Specify a version semver to associate with the artifact. The version specified can be used in the deploy command to select this artifact.",
+		Description: "Upload (push) an artifact containing the source for your application. Specify a semver version to associate with the artifact. The version specified can be used in the deploy command to select this artifact.",
 		Usage:       "Push artifact",
 		UsageText:   "nullstone push [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -12,9 +12,10 @@ import (
 // Push command performs a docker push to an authenticated image registry configured against an app/container
 var Push = func(providers app.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "push",
-		Usage:     "Push artifact",
-		UsageText: "nullstone push [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Name:        "push",
+		Description: "Upload (push) an artifact containing the source for your application. Specify a version semver to associate with the artifact. The version specified can be used in the deploy command to select this artifact.",
+		Usage:       "Push artifact",
+		UsageText:   "nullstone push [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,

--- a/cmd/set_org.go
+++ b/cmd/set_org.go
@@ -8,12 +8,11 @@ import (
 )
 
 var SetOrg = &cli.Command{
-	Name:  "set-org",
-	Usage: "Set the organization for the CLI",
-	UsageText: `Most Nullstone CLI commands require a configured nullstone organization to operate.
-   This command will set the organization for the current profile.
-   If you wish to set the organization per command, use the global --org flag instead.`,
-	Flags: []cli.Flag{},
+	Name:        "set-org",
+	Description: "Most Nullstone CLI commands require a configured nullstone organization to operate. This command will set the organization for the current profile. If you wish to set the organization per command, use the global `--org` flag instead.",
+	Usage:       "Set the organization for the CLI",
+	UsageText:   `nullstone set-org <org-name>`,
+	Flags:       []cli.Flag{},
 	Action: func(c *cli.Context) error {
 		profile, err := config.LoadProfile(GetProfile(c))
 		if err != nil {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -14,9 +14,10 @@ import (
 
 var Ssh = func(providers admin.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "ssh",
-		Usage:     "SSH into a running service. Use to forward ports from remote service or hosts.",
-		UsageText: "nullstone ssh [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Name:        "ssh",
+		Description: "SSH into a running app container or virtual machine. Use the `--forward, L` option to forward ports from remote service or hosts.",
+		Usage:       "SSH into a running application.",
+		UsageText:   "nullstone ssh [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,
@@ -47,7 +48,7 @@ var Ssh = func(providers admin.Providers) *cli.Command {
 				} else if remoter == nil {
 					module := appDetails.Module
 					platform := strings.TrimSuffix(fmt.Sprintf("%s:%s", module.Platform, module.Subplatform), ":")
-					return fmt.Errorf("The Nullstone CLI does not currently support the ssh command for the %q application. (Module = %s, App Category = app/%s, Platform = %s)",
+					return fmt.Errorf("The Nullstone CLI does not currently support the ssh command for the %q application. (Module = %s/%s, App Category = app/%s, Platform = %s)",
 						appDetails.App.Name, module.OrgName, module.Name, module.Subcategory, platform)
 				}
 				return remoter.Ssh(ctx, task, forwards)

--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -19,13 +19,15 @@ var Stacks = &cli.Command{
 }
 
 var StacksList = &cli.Command{
-	Name:      "list",
-	Usage:     "List stacks",
-	UsageText: "nullstone stacks list",
+	Name:        "list",
+	Description: "Shows a list of the stacks that you have access to. Set the `--detail` flag to show more details about each stack.",
+	Usage:       "List stacks",
+	UsageText:   "nullstone stacks list",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "detail",
 			Aliases: []string{"d"},
+			Usage:   "Use this flag to show more details about each stack",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -55,12 +57,21 @@ var StacksList = &cli.Command{
 }
 
 var StacksNew = &cli.Command{
-	Name:      "new",
-	Usage:     "Create new stack",
-	UsageText: "nullstone stacks new --name=<name> --description=<description>",
+	Name:        "new",
+	Description: "Creates a new stack with the given name and in the organization configured for the CLI.",
+	Usage:       "Create new stack",
+	UsageText:   "nullstone stacks new --name=<name> --description=<description>",
 	Flags: []cli.Flag{
-		&cli.StringFlag{Name: "name", Required: true},
-		&cli.StringFlag{Name: "description", Required: true},
+		&cli.StringFlag{
+			Name:     "name",
+			Usage:    "The name of the stack to create. This name must be unique within the organization.",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "description",
+			Usage:    "The description of the stack to create.",
+			Required: true,
+		},
 	},
 	Action: func(c *cli.Context) error {
 		return ProfileAction(c, func(cfg api.Config) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,9 +18,10 @@ var (
 
 var Status = func(providers admin.Providers) *cli.Command {
 	return &cli.Command{
-		Name:      "status",
-		Usage:     "Application Status",
-		UsageText: "nullstone status [--stack=<stack-name>] --app=<app-name> [--env=<env-name>] [options]",
+		Name:        "status",
+		Description: "View the status of your application and whether it is starting up, running, stopped, etc. This command shows the status of an application's tasks as well as the health of the load balancer.",
+		Usage:       "Application Status",
+		UsageText:   "nullstone status [--stack=<stack-name>] --app=<app-name> [--env=<env-name>] [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			AppFlag,
@@ -29,6 +30,7 @@ var Status = func(providers admin.Providers) *cli.Command {
 			&cli.BoolFlag{
 				Name:    "watch",
 				Aliases: []string{"w"},
+				Usage:   "Pass this flag in order to watch status updates in real time. Changes will be automatically displayed as they occur.",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -14,7 +14,7 @@ import (
 var Up = func() *cli.Command {
 	return &cli.Command{
 		Name:        "up",
-		Description: "Launches the infrastructure for the given block and environment as well as all it's dependencies.",
+		Description: "Launches the infrastructure for the given block/environment and it's dependencies.",
 		Usage:       "Provisions the block and all of its dependencies",
 		UsageText:   "nullstone up [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -13,9 +13,10 @@ import (
 
 var Up = func() *cli.Command {
 	return &cli.Command{
-		Name:      "up",
-		Usage:     "Provisions the block and all of its dependencies",
-		UsageText: "nullstone up [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		Name:        "up",
+		Description: "Launches the infrastructure for the given block and environment as well as all it's dependencies.",
+		Usage:       "Provisions the block and all of its dependencies",
+		UsageText:   "nullstone up [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,
@@ -23,11 +24,11 @@ var Up = func() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "wait",
 				Aliases: []string{"w"},
-				Usage:   "Wait for Nullstone to fully provision the workspace.",
+				Usage:   "Wait for the launch to complete and stream the Terraform logs to the console.",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
-				Usage: "Set variable values when issuing `up`",
+				Usage: "Set variables values for the plan. This can be used to override variables defined in the module.",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -24,7 +24,7 @@ var Workspaces = &cli.Command{
 
 var WorkspacesSelect = &cli.Command{
 	Name:        "select",
-	Description: "Sync a given workspace's state with the current directory. Running this command will allow you to run terraform plans locally against the selected workspace.",
+	Description: "Sync a given workspace's state with the current directory. Running this command will allow you to run terraform plans/applies locally against the selected workspace.",
 	Usage:       "Select workspace",
 	UsageText:   "nullstone workspaces select [--stack=<stack>] --block=<block> --env=<env>",
 	Flags: []cli.Flag{

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -23,17 +23,20 @@ var Workspaces = &cli.Command{
 }
 
 var WorkspacesSelect = &cli.Command{
-	Name:      "select",
-	Usage:     "Select workspace",
-	UsageText: "nullstone workspaces select [--stack=<stack>] --block=<block> --env=<env>",
+	Name:        "select",
+	Description: "Sync a given workspace's state with the current directory. Running this command will allow you to run terraform plans locally against the selected workspace.",
+	Usage:       "Select workspace",
+	UsageText:   "nullstone workspaces select [--stack=<stack>] --block=<block> --env=<env>",
 	Flags: []cli.Flag{
 		StackFlag,
 		&cli.StringFlag{
 			Name:     "block",
+			Usage:    "Name of the block to use for this operation",
 			Required: true,
 		},
 		&cli.StringFlag{
 			Name:     "env",
+			Usage:    `Name of the environment to use for this operation`,
 			Required: true,
 		},
 	},

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,418 @@
+# CLI Docs
+Cheat sheet and reference for the Nullstone CLI.
+
+This document contains a list of all the commands available in the Nullstone CLI along with:
+- descriptions
+- when to use them
+- examples
+- options
+
+## apply
+Runs a Terraform apply on the given block and environment. This is useful for making ad-hoc changes to your infrastructure.
+Be sure to run `nullstone plan` first to see what changes will be made.
+
+#### Usage
+```shell
+$ nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--block` | Name of the block to use for this operation | required |
+| `--env` | Name of the environment to use for this operation | required |
+| `--wait, -w` | Wait for the apply to complete and stream the Terraform logs to the console. |  |
+| `--auto-approve` | Skip any approvals and apply the changes immediately. This requires proper permissions in the stack. |  |
+| `--var` | Set variables values for the apply. This can be used to override variables defined in the module. |  |
+| `--module-version` | The version of the module to apply. |  |
+
+
+## apps list
+Shows a list of the applications that you have access to. Set the `--detail` flag to show more details about each application.
+
+#### Usage
+```shell
+$ nullstone apps list
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--detail, -d` | Use this flag to show the details for each application |  |
+
+
+## blocks list
+Shows a list of the blocks for the given stack. Set the `--detail` flag to show more details about each block.
+
+#### Usage
+```shell
+$ nullstone blocks list --stack=<stack>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Set the stack to use for this operation | required |
+| `--detail, -d` | Use this flag to show more details about each block |  |
+
+
+## blocks new
+Creates a new block with the given name and module. If the module has any connections, you can specify them using the `--connection` parameter.
+
+#### Usage
+```shell
+$ nullstone blocks new --name=<name> --stack=<stack> --module=<module> [--connection=<connection>...]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Set the stack to use for this operation | required |
+| `--name` | Provide a name for this new block | required |
+| `--module` | Specify the unique name of the module to use for this block. Example: nullstone/aws-network | required |
+| `--connection` | Specify any connections that this block will have to other blocks. Use the connection name as the key, and the connected block name as the value. Example: --connection network=network0 |  |
+
+
+## configure
+Establishes a profile and configures authentication for the CLI to use.
+
+#### Usage
+```shell
+$ nullstone configure --api-key=<api-key>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--address` | Specify the url for the Nullstone API. |  |
+| `--api-key` | Configure your personal API key that will be used to authenticate with the Nullstone API. You can generate an API key from your profile page. |  |
+
+
+## deploy
+Deploy a new version of your code for this application. This command works in tandem with the `nullstone push` command. This command deploys the artifacts that were uploaded during the `push` command.
+
+#### Usage
+```shell
+$ nullstone deploy [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+| `--wait, -w` | Wait for the deploy to complete and stream the logs to the console. |  |
+
+
+## envs list
+Shows a list of the environments for the given stack. Set the `--detail` flag to show more details about each environment.
+
+#### Usage
+```shell
+$ nullstone envs list --stack=<stack-name>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Set the stack to use for this operation | required |
+| `--detail, -d` | Use this flag to show more details about each environment |  |
+
+
+## envs new
+Creates a new environment in the given stack. The environment will be created as the last environment in the pipeline. Specify the provider, region, and zone to determine where infrastructure will be provisioned for this environment.
+
+#### Usage
+```shell
+$ nullstone envs new --name=<name> --stack=<stack> --provider=<provider>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--name` | Provide a name for this new environment | required |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--provider` | Provide the name of the provider to use for this environment | required |
+| `--region` | Select which region to launch infrastructure for this environment. Defaults to us-east-1 for AWS and us-east1 for GCP. |  |
+| `--zone` | For GCP, select the zone to launch infrastructure for this environment. Defaults to us-east1b |  |
+
+
+## exec
+Executes a command on a container or the virtual machine for the given application. Defaults command to '/bin/sh' which acts as opening a shell to the running container or virtual machine.
+
+#### Usage
+```shell
+$ nullstone exec [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options] [command]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation | required |
+| `--task` | Select a specific task/replica to execute the command against.		This is optional and by default will connect to a random task/replica.       	If using Kubernetes, this will select which replica of the pod to connect.       	If using ECS, this will select which task of the service to connect. |  |
+
+
+## launch
+This command will first upload (push) an artifact containing the source for your application. Then it will deploy it to the given environment and tail the logs for the deployment.This command is the same as running `nullstone push` followed by `nullstone deploy -w`.
+
+#### Usage
+```shell
+$ nullstone launch [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--source` | The source artifact to push that contains your application's build.		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.		For a serverless zip application, specify the .zip archive to push. | required |
+| `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+
+
+## logs
+Streams an application's logs to the console for the given environment. Use the start-time `-s` and end-time `-e` flags to only show logs for a given time period. Use the tail flag `-t` to stream the logs in real time.
+
+#### Usage
+```shell
+$ nullstone logs [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--start-time, -s` |        Emit log events that occur after the specified start-time.        This is a golang duration relative to the time the command is issued.       Examples: '5s' (5 seconds ago), '1m' (1 minute ago), '24h' (24 hours ago)       |  |
+| `--end-time, -e` |        Emit log events that occur before the specified end-time.        This is a golang duration relative to the time the command is issued.       Examples: '5s' (5 seconds ago), '1m' (1 minute ago), '24h' (24 hours ago)       |  |
+| `--interval` | Set --interval to a golang duration to control how often to pull new log events.       This will do nothing unless --tail is set. The default is 1 second.       |  |
+| `--tail, -t` | Set tail to watch log events and emit as they are reported.       Use --interval to control how often to query log events.       This is off by default. Unless this option is provided, this command will exit as soon as current log events are emitted. |  |
+
+
+## modules generate
+Generates a nullstone manifest file for your module in the current directory. You will be asked a series of questions in order to collect the information needed to describe a Nullstone module. Optionally, you can also register the module in the Nullstone registry by passing the `--register` flag.
+
+#### Usage
+```shell
+$ nullstone modules generate [--register]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--register` | Register the module in the Nullstone registry after generating the manifest file. |  |
+
+
+## modules register
+Registers a module in the Nullstone registry. The information in .nullstone/module.yml will be used as the details for the new module.
+
+#### Usage
+```shell
+$ nullstone modules register
+```
+
+## modules publish
+Publishes a new version for a module in the Nullstone registry. Provide a specific version semver using the `--version` parameter.
+
+#### Usage
+```shell
+$ nullstone modules publish --version=<version>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--version, -v` | Specify a semver version for the module.'next-patch': Uses a version that bumps the patch component of the latest module version.'next-build': Uses the latest version and appends +`build` using the short Git commit SHA. (Fails if not in a Git repository) | required |
+| `--include` | Specify additional file patterns to package. By default, this command includes *.tf, *.tf.tmpl, and 'README.md'. Use this flag to package additional modules and files needed for applies. This supports file globbing detailed at https://pkg.go.dev/path/filepath#Glob |  |
+
+
+## modules package
+Package all the module contents for a Nullstone module into a tarball but do not publish to the registry.
+
+#### Usage
+```shell
+$ nullstone modules package
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--include` | Specify additional file patterns to package. By default, this command includes *.tf, *.tf.tmpl, and 'README.md'. Use this flag to package additional modules and files needed for applies. This supports file globbing detailed at https://pkg.go.dev/path/filepath#Glob |  |
+
+
+## outputs
+Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. For less information in an easier to read format, use the `--plain` flag.
+
+#### Usage
+```shell
+$ nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--block` | Name of the block to use for this operation | required |
+| `--env` | Name of the environment to use for this operation | required |
+| `--sensitive` | Include sensitive outputs in the results |  |
+| `--plain` | Print less information about the outputs in a more readable format |  |
+
+
+## plan
+Run a plan for a given block and environment. This will automatically disapprove the plan and is useful for testing what a plan will do.
+
+#### Usage
+```shell
+$ nullstone plan [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--block` | Name of the block to use for this operation | required |
+| `--env` | Name of the environment to use for this operation | required |
+| `--wait, -w` | Wait for the apply to complete and stream the Terraform logs to the console. |  |
+| `--var` | Set variables values for the plan. This can be used to override variables defined in the module. |  |
+| `--module-version` | Run a plan with a specific version of the module. |  |
+
+
+## push
+Upload (push) an artifact containing the source for your application. Specify a version semver to associate with the artifact. The version specified can be used in the deploy command to select this artifact.
+
+#### Usage
+```shell
+$ nullstone push [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--source` | The source artifact to push that contains your application's build.		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.		For a serverless zip application, specify the .zip archive to push. | required |
+| `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+
+
+## set-org
+Most Nullstone CLI commands require a configured nullstone organization to operate. This command will set the organization for the current profile. If you wish to set the organization per command, use the global `--org` flag instead.
+
+#### Usage
+```shell
+$ nullstone set-org <org-name>
+```
+
+## ssh
+SSH into a running app container or virtual machine. Use the `--forward, L` option to forward ports from remote service or hosts.
+
+#### Usage
+```shell
+$ nullstone ssh [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation | required |
+| `--task` | Select a specific task/replica to execute the command against.		This is optional and by default will connect to a random task/replica.       	If using Kubernetes, this will select which replica of the pod to connect.       	If using ECS, this will select which task of the service to connect. |  |
+| `--forward, -L` | Use this to forward ports from host to local machine. Format: `local-port`:[`remote-host`]:`remote-port` |  |
+
+
+## stacks list
+Shows a list of the stacks that you have access to. Set the `--detail` flag to show more details about each stack.
+
+#### Usage
+```shell
+$ nullstone stacks list
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--detail, -d` | Use this flag to show more details about each stack |  |
+
+
+## stacks new
+Creates a new stack with the given name and in the organization configured for the CLI.
+
+#### Usage
+```shell
+$ nullstone stacks new --name=<name> --description=<description>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--name` | The name of the stack to create. This name must be unique within the organization. | required |
+| `--description` | The description of the stack to create. | required |
+
+
+## status
+View the status of your application and whether it is starting up, running, stopped, etc. This command shows the status of an application's tasks as well as the health of the load balancer.
+
+#### Usage
+```shell
+$ nullstone status [--stack=<stack-name>] --app=<app-name> [--env=<env-name>] [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+| `--watch, -w` | Pass this flag in order to watch status updates in real time. Changes will be automatically displayed as they occur. |  |
+
+
+## up
+Launches the infrastructure for the given block and environment as well as all it's dependencies.
+
+#### Usage
+```shell
+$ nullstone up [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--block` | Name of the block to use for this operation | required |
+| `--env` | Name of the environment to use for this operation | required |
+| `--wait, -w` | Wait for the launch to complete and stream the Terraform logs to the console. |  |
+| `--var` | Set variables values for the plan. This can be used to override variables defined in the module. |  |
+
+
+## version
+Prints the version of the CLI.
+
+#### Usage
+```shell
+nullstone -v
+```
+
+## workspaces select
+Sync a given workspace's state with the current directory. Running this command will allow you to run terraform plans locally against the selected workspace.
+
+#### Usage
+```shell
+$ nullstone workspaces select [--stack=<stack>] --block=<block> --env=<env>
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--block` | Name of the block to use for this operation | required |
+| `--env` | Name of the environment to use for this operation | required |
+
+

--- a/docs/main.go
+++ b/docs/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
+	"log"
+	"os"
+	"strings"
+)
+
+func main() {
+	log.Println("Generating CLI docs...")
+	cliApp := app.Build()
+
+	filename := "docs/CLI.md"
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Fatalf("unable to open %s for writing: %v", filename, err)
+	}
+	defer f.Close()
+
+	f.WriteString("# CLI Docs\n")
+	f.WriteString("Cheat sheet and reference for the Nullstone CLI.\n\n")
+	f.WriteString("This document contains a list of all the commands available in the Nullstone CLI along with:\n")
+	f.WriteString("- descriptions\n")
+	f.WriteString("- when to use them\n")
+	f.WriteString("- examples\n")
+	f.WriteString("- options\n\n")
+
+	for _, command := range cliApp.Commands {
+		if len(command.Subcommands) > 0 {
+			for _, subcommand := range command.Subcommands {
+				outputCommandDocs(f, &command.Name, subcommand)
+			}
+		} else {
+			outputCommandDocs(f, nil, command)
+		}
+	}
+}
+
+func formatUsageText(usageText string) string {
+	result := strings.Replace(usageText, "\n", "", -1)
+	result = strings.Replace(result, "<", "`", -1)
+	result = strings.Replace(result, ">", "`", -1)
+	return result
+}
+
+func formatFlagName(name string, aliases []string) string {
+	if len(aliases) > 0 {
+		return fmt.Sprintf("`--%s, -%s`", name, strings.Join(aliases, ", "))
+	}
+	return fmt.Sprintf("`--%s`", name)
+}
+
+func formatRequired(required bool) string {
+	if required {
+		return "required"
+	}
+	return ""
+}
+
+func outputCommandDescription(f *os.File, name string, description string) {
+	if name == "version" {
+		f.WriteString("Prints the version of the CLI.\n\n")
+	} else {
+		f.WriteString(description + "\n\n")
+	}
+}
+
+func outputCommandUsage(f *os.File, name, usage string) {
+	f.WriteString("#### Usage\n")
+	f.WriteString("```shell\n")
+	if name == "version" {
+		f.WriteString("nullstone -v\n")
+	} else {
+		f.WriteString(fmt.Sprintf("$ %s\n", usage))
+	}
+	f.WriteString("```\n\n")
+}
+
+func outputCommandOptions(f *os.File, flags []cli.Flag) {
+	if len(flags) > 0 {
+		f.WriteString("#### Options\n")
+		f.WriteString("| Option | Description | |\n")
+		f.WriteString("| --- | --- | --- |\n")
+		for _, flag := range flags {
+			if sf, ok := flag.(*cli.StringFlag); ok {
+				f.WriteString(fmt.Sprintf("| %s | %s | %s |\n", formatFlagName(sf.Name, sf.Aliases), formatUsageText(sf.Usage), formatRequired(sf.Required)))
+			} else if bf, ok := flag.(*cli.BoolFlag); ok {
+				f.WriteString(fmt.Sprintf("| %s | %s | %s |\n", formatFlagName(bf.Name, bf.Aliases), formatUsageText(bf.Usage), formatRequired(bf.Required)))
+			} else if df, ok := flag.(*cli.DurationFlag); ok {
+				f.WriteString(fmt.Sprintf("| %s | %s | %s |\n", formatFlagName(df.Name, df.Aliases), formatUsageText(df.Usage), formatRequired(df.Required)))
+			} else if ssf, ok := flag.(*cli.StringSliceFlag); ok {
+				f.WriteString(fmt.Sprintf("| %s | %s | %s |\n", formatFlagName(ssf.Name, ssf.Aliases), formatUsageText(ssf.Usage), formatRequired(ssf.Required)))
+			} else {
+				log.Printf("Skipping flag: %+v\n", flag)
+			}
+		}
+		f.WriteString("\n\n")
+	}
+}
+
+func outputCommandDocs(f *os.File, prefix *string, command *cli.Command) {
+	name := command.Name
+	if prefix != nil {
+		name = fmt.Sprintf("%s %s", *prefix, name)
+	}
+	log.Printf("Generating docs for %s", name)
+	f.WriteString(fmt.Sprintf("## %s\n", name))
+	outputCommandDescription(f, name, command.Description)
+	outputCommandUsage(f, name, command.UsageText)
+	outputCommandOptions(f, command.Flags)
+}

--- a/nullstone/main.go
+++ b/nullstone/main.go
@@ -4,68 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	allApp "github.com/nullstone-io/deployment-sdk/app/all"
-	"github.com/urfave/cli/v2"
-	allAdmin "gopkg.in/nullstone-io/nullstone.v0/admin/all"
-	"gopkg.in/nullstone-io/nullstone.v0/cmd"
+	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"os"
-	"sort"
-)
-
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-	builtBy = "unknown"
 )
 
 func main() {
-	appProviders := allApp.Providers
-	adminProviders := allAdmin.Providers
-
-	cliApp := &cli.App{
-		Version:              version,
-		EnableBashCompletion: true,
-		Metadata: map[string]interface{}{
-			"commit":  commit,
-			"date":    date,
-			"builtBy": builtBy,
-		},
-		Flags: []cli.Flag{
-			cmd.ProfileFlag,
-			cmd.OrgFlag,
-		},
-		Commands: []*cli.Command{
-			{
-				Name: "version",
-				Action: func(c *cli.Context) error {
-					cli.ShowVersion(c)
-					return nil
-				},
-			},
-			cmd.Configure,
-			cmd.SetOrg,
-			cmd.Stacks,
-			cmd.Envs,
-			cmd.Apps,
-			cmd.Blocks,
-			cmd.Modules,
-			cmd.Workspaces,
-			cmd.Up(),
-			cmd.Plan(),
-			cmd.Apply(),
-			cmd.Outputs(),
-			cmd.Push(appProviders),
-			cmd.Deploy(appProviders),
-			cmd.Launch(appProviders),
-			cmd.Logs(adminProviders),
-			cmd.Status(adminProviders),
-			cmd.Exec(adminProviders),
-			cmd.Ssh(adminProviders),
-		},
-	}
-	sort.Sort(cli.FlagsByName(cliApp.Flags))
-	sort.Sort(cli.CommandsByName(cliApp.Commands))
+	cliApp := app.Build()
 
 	err := cliApp.Run(os.Args)
 	if err != nil {


### PR DESCRIPTION
This PR adds a new routine that generates a proper markdown file (docs/CLI.md) based on the commands built for our CLI.

Generating these docs also pointed out a lack of documentation in some places and some opportunities to improve for others. Please review my changes to the commands and make sure they are all correct and that you are ok with the changes.

To generate the CLI.md file, simply run `make docs`.