### PR TITLE
Forward OS signals to ssh process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.90 (Jan 06, 2022)
+* Improved `nullstone ssh` to forward OS signals (e.g. `Ctrl+C`) so it does not terminate SSH tunnel.
+
 # 0.0.89 (Dec 01, 2022)
 * Fixed retrieval of module versions if none exist for a module.
 


### PR DESCRIPTION
If you `nullstone ssh` to an app, then start typing a command, but want to cancel using `Cmd+C` or `Ctrl+C`, the SSH shell will exit. Then, you have to reissue `nullstone ssh`.

This fix changes the execution of AWS ssh command to trap the OS signals and forward them to the child process.