### PR TITLE
Changed display format for times to readable, local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.97 (Mar 11, 2023)
+* Changed `nullstone status` display format for times to emit local times using "Mon Jan _2 15:04:05 MST". 
+* Changed `nullstone logs` display format for times to emit local times using "Mon Jan _2 15:04:05 MST". 
+
 # 0.0.96 (Feb 24, 2023)
 * Added `Variable.HasValue` helper function when running capability generation (`nullstone workspaces select`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.97 (Mar 11, 2023)
+# 0.0.97 (Mar 13, 2023)
 * Changed `nullstone status` display format for times to emit local times using "Mon Jan _2 15:04:05 MST". 
 * Changed `nullstone logs` display format for times to emit local times using "Mon Jan _2 15:04:05 MST". 
 

--- a/aws/cloudwatch/log_streamer.go
+++ b/aws/cloudwatch/log_streamer.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/admin"
 	"gopkg.in/nullstone-io/nullstone.v0/config"
+	"gopkg.in/nullstone-io/nullstone.v0/display"
 	"log"
 	"os"
 	"time"
@@ -50,7 +51,7 @@ func (l LogStreamer) Stream(ctx context.Context, options config.LogStreamOptions
 
 	emitter := func(event cwltypes.FilteredLogEvent) {
 		timestamp := time.Unix(*event.Timestamp/1000, 0)
-		normal.Fprintf(stdout, "%s ", timestamp.Format(time.RFC822Z))
+		normal.Fprintf(stdout, "%s ", display.FormatTime(timestamp))
 		bold.Fprintf(stdout, "[%s]", *event.LogStreamName)
 		normal.Fprintf(stdout, " %s", *event.Message)
 		normal.Fprintln(stdout)

--- a/aws/ecs/statuser.go
+++ b/aws/ecs/statuser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/admin"
+	"gopkg.in/nullstone-io/nullstone.v0/display"
 )
 
 func NewStatuser(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (admin.Statuser, error) {
@@ -61,7 +62,7 @@ func (s Statuser) StatusDetail(ctx context.Context) (admin.StatusDetailReports, 
 		record := admin.StatusRecord{
 			Fields: []string{"Created", "Status", "Running", "Desired", "Pending"},
 			Data: map[string]interface{}{
-				"Created": fmt.Sprintf("%s", *deployment.CreatedAt),
+				"Created": display.FormatTimePtr(deployment.CreatedAt),
 				"Status":  *deployment.Status,
 				"Running": fmt.Sprintf("%d", deployment.RunningCount),
 				"Desired": fmt.Sprintf("%d", deployment.DesiredCount),

--- a/config/log_stream_options.go
+++ b/config/log_stream_options.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"gopkg.in/nullstone-io/nullstone.v0/display"
 	"time"
 )
 
@@ -22,11 +23,11 @@ type LogStreamOptions struct {
 func (o LogStreamOptions) QueryTimeMessage() string {
 	if o.StartTime != nil {
 		if o.EndTime != nil {
-			return fmt.Sprintf("Querying logs between %s and %s", o.StartTime.Format(time.RFC822), o.EndTime.Format(time.RFC822))
+			return fmt.Sprintf("Querying logs between %s and %s", display.FormatTimePtr(o.StartTime), display.FormatTimePtr(o.EndTime))
 		}
-		return fmt.Sprintf("Querying logs starting %s", o.StartTime.Format(time.RFC822))
+		return fmt.Sprintf("Querying logs starting %s", display.FormatTimePtr(o.StartTime))
 	} else if o.EndTime != nil {
-		return fmt.Sprintf("Querying logs until %s", o.EndTime.Format(time.RFC822))
+		return fmt.Sprintf("Querying logs until %s", display.FormatTimePtr(o.EndTime))
 	}
 	return fmt.Sprintf("Querying all logs")
 }

--- a/display/format_time.go
+++ b/display/format_time.go
@@ -1,0 +1,20 @@
+package display
+
+import (
+	"time"
+)
+
+const (
+	CommonFormat = "Mon Jan _2 15:04:05 MST"
+)
+
+func FormatTime(t time.Time) string {
+	return t.In(time.Local).Format(CommonFormat)
+}
+
+func FormatTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.In(time.Local).Format(CommonFormat)
+}


### PR DESCRIPTION
Example:
```
$ nullstone status ...
Env: beta       Infra: provisioned      Version: 9dcb9e9f

Deployments
Created                  Status   Running  Desired  Pending
Fri Mar 10 16:57:12 EST  PRIMARY  1        1        0

Load Balancers
Port  Target        Status
8080  10.0.102.213  healthy
```