### PR TITLE
Adding support for cluster-namespace for ecs apps

### DIFF
--- a/aws/ecs/exec_command.go
+++ b/aws/ecs/exec_command.go
@@ -8,7 +8,7 @@ import (
 
 func ExecCommand(ctx context.Context, infra Outputs, taskId string, cmd string, parameters map[string][]string) error {
 	region := infra.Region
-	cluster := infra.Cluster.ClusterArn
+	cluster := infra.ClusterArn()
 	containerName := infra.MainContainerName
 	awsConfig := nsaws.NewConfig(infra.Deployer, region)
 

--- a/aws/ecs/get_service.go
+++ b/aws/ecs/get_service.go
@@ -12,7 +12,7 @@ func GetService(ctx context.Context, infra Outputs) (*ecstypes.Service, error) {
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	out, err := ecsClient.DescribeServices(ctx, &ecs.DescribeServicesInput{
 		Services: []string{infra.ServiceName},
-		Cluster:  aws.String(infra.Cluster.ClusterArn),
+		Cluster:  aws.String(infra.ClusterArn()),
 	})
 	if err != nil {
 		return nil, err

--- a/aws/ecs/get_tasks.go
+++ b/aws/ecs/get_tasks.go
@@ -10,7 +10,7 @@ import (
 func GetTasks(ctx context.Context, infra Outputs) ([]string, error) {
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	out, err := ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster:     aws.String(infra.Cluster.ClusterArn),
+		Cluster:     aws.String(infra.ClusterArn()),
 		ServiceName: aws.String(infra.ServiceName),
 	})
 	if err != nil {

--- a/aws/ecs/outputs.go
+++ b/aws/ecs/outputs.go
@@ -11,7 +11,19 @@ type Outputs struct {
 	MainContainerName string     `ns:"main_container_name,optional"`
 	Deployer          nsaws.User `ns:"deployer,optional"`
 
-	Cluster ClusterOutputs `ns:",connectionContract:cluster/aws/ecs:*"`
+	Cluster          ClusterOutputs          `ns:",connectionContract:cluster/aws/ecs:*,optional"`
+	ClusterNamespace ClusterNamespaceOutputs `ns:",connectionContract:cluster-namespace/aws/ecs:*,optional"`
+}
+
+func (o Outputs) ClusterArn() string {
+	if o.ClusterNamespace.ClusterArn != "" {
+		return o.ClusterNamespace.ClusterArn
+	}
+	return o.Cluster.ClusterArn
+}
+
+type ClusterNamespaceOutputs struct {
+	ClusterArn string `ns:"cluster_arn"`
 }
 
 type ClusterOutputs struct {


### PR DESCRIPTION
This adds `cluster-namespace` as an optional connection to ecs apps.
Additionally, the `cluster` connection was marked optional so that users could safely upgrade without breaking deployments.