### PR TITLE
B/1627/missing stack panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.104 (Jul 28, 2023)
+* Fixed nil panic when specifying `--stack` that does not exist.
+
 # 0.0.103 (Jun 07, 2023)
 * Added support for `nullstone ssh` for GKE apps.
 * Added support for `nullstone logs` for GKE apps.

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -265,7 +265,19 @@ func createPipelineEnv(client api.Client, stackId int64, name, providerName, reg
 }
 
 func createPreviewEnv(client api.Client, stackId int64, name string) error {
-	env, err := client.PreviewEnvs().Create(stackId, &api.CreatePreviewEnvInput{Name: name})
+	newEnv, err := client.Environments().Create(stackId, &types.Environment{
+		OrgName: client.Config.OrgName,
+		StackId: stackId,
+		Name:    name,
+		Type:    types.EnvTypePreview,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating preview environment: %w", err)
+	} else if newEnv == nil {
+		return fmt.Errorf("unable to create preview environment")
+	}
+
+	env, err := client.PreviewEnvs().Update(stackId, newEnv.Id, &api.UpdatePreviewEnvInput{Name: &name})
 	if err != nil {
 		return fmt.Errorf("error creating preview environment: %w", err)
 	}

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -265,7 +265,7 @@ func createPipelineEnv(client api.Client, stackId int64, name, providerName, reg
 }
 
 func createPreviewEnv(client api.Client, stackId int64, name string) error {
-	newEnv, err := client.Environments().Create(stackId, &types.Environment{
+	env, err := client.Environments().Create(stackId, &types.Environment{
 		OrgName: client.Config.OrgName,
 		StackId: stackId,
 		Name:    name,
@@ -273,14 +273,10 @@ func createPreviewEnv(client api.Client, stackId int64, name string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error creating preview environment: %w", err)
-	} else if newEnv == nil {
+	} else if env == nil {
 		return fmt.Errorf("unable to create preview environment")
 	}
 
-	env, err := client.PreviewEnvs().Update(stackId, newEnv.Id, &api.UpdatePreviewEnvInput{Name: &name})
-	if err != nil {
-		return fmt.Errorf("error creating preview environment: %w", err)
-	}
 	fmt.Printf("created %q preview environment\n", env.Name)
 	return nil
 }

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -172,7 +172,7 @@ var ModulesPublish = &cli.Command{
 			defer tarball.Close()
 
 			client := api.Client{Config: cfg}
-			if err := client.Org(manifest.OrgName).ModuleVersions().Create(manifest.Name, version, tarball); err != nil {
+			if err := client.ModuleVersions().Create(manifest.OrgName, manifest.Name, version, tarball); err != nil {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "Published %s/%s@%s\n", manifest.OrgName, manifest.Name, version)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.1.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230418131255-5f3761a283b3
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.1.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728154236-b83715593537
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -1501,8 +1501,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230418131255-5f3761a283b3 h1:HR09PNDqA4mM5r5TwOzgFVqQvAIRI/6X7q2eX93pS3I=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230418131255-5f3761a283b3/go.mod h1:2zMwhz2lArnK8cPNYLStJoAtOPQMq01GPguwwpqH7I8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c h1:GuMCwAN1HqLDhe8zYSvoy2eZ/SfDtDAQhH9HRpucO3Y=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c/go.mod h1:2zMwhz2lArnK8cPNYLStJoAtOPQMq01GPguwwpqH7I8=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1501,8 +1501,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c h1:GuMCwAN1HqLDhe8zYSvoy2eZ/SfDtDAQhH9HRpucO3Y=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728151954-1fc220abf16c/go.mod h1:2zMwhz2lArnK8cPNYLStJoAtOPQMq01GPguwwpqH7I8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728154236-b83715593537 h1:Tv6CuboikkX5tD13RQ48TGd4NR/h6GnCuK6JibaLUKQ=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20230728154236-b83715593537/go.mod h1:2zMwhz2lArnK8cPNYLStJoAtOPQMq01GPguwwpqH7I8=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/modules/register.go
+++ b/modules/register.go
@@ -23,8 +23,8 @@ func Register(cfg api.Config, manifest *Manifest) (*types.Module, error) {
 	}
 
 	client := api.Client{Config: cfg}
-	if err := client.Org(module.OrgName).Modules().Create(module); err != nil {
+	if err := client.Modules().Create(module.OrgName, module); err != nil {
 		return nil, err
 	}
-	return client.Org(module.OrgName).Modules().Get(module.Name)
+	return client.Modules().Get(module.OrgName, module.Name)
 }


### PR DESCRIPTION
This updates the CLI with a new go-api-client to fix a nil panic when streaming logs for a stack that doesn't exist:
```
nullstone logs --stack=abc --env=prod --app=app
```

There were other updates to go-api-client since it's last update; this updates references to the endpoints that have changed.


#### TODO
- [x] Review and merge https://github.com/nullstone-io/go-api-client/pull/63
- [x] `go mod tidy && go mod vendor`