### PR TITLE
F1815 deploy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.115 (Feb 15, 2024)
+* Provided a better mechanism for default deploy versions. This allows multiple deploys to be run from the same git commit sha.
+
 # 0.0.114 (Feb 15, 2024)
 * Sanitizing environment name before creating in `envs new` command.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.115 (Feb 15, 2024)
 * Provided a better mechanism for default deploy versions. This allows multiple deploys to be run from the same git commit sha.
+* Always record the git commit sha on the deploy.
 
 # 0.0.114 (Feb 15, 2024)
 * Sanitizing environment name before creating in `envs new` command.

--- a/cmd/create_deploy.go
+++ b/cmd/create_deploy.go
@@ -7,9 +7,14 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func CreateDeploy(nsConfig api.Config, appDetails app.Details, version string) (*types.Deploy, error) {
+func CreateDeploy(nsConfig api.Config, appDetails app.Details, commitSha, version string) (*types.Deploy, error) {
 	client := api.Client{Config: nsConfig}
-	newDeploy, err := client.Deploys().Create(appDetails.App.StackId, appDetails.App.Id, appDetails.Env.Id, version, false)
+	payload := api.DeployCreatePayload{
+		FromSource: false,
+		Version:    version,
+		CommitSha:  commitSha,
+	}
+	newDeploy, err := client.Deploys().Create(appDetails.App.StackId, appDetails.App.Id, appDetails.Env.Id, payload)
 	if err != nil {
 		return nil, fmt.Errorf("error creating deploy: %w", err)
 	} else if newDeploy == nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -71,7 +71,8 @@ func getCurrentVersion(ctx context.Context, pusher app.Pusher) (string, error) {
 
 	artifacts, err := pusher.ListArtifactVersions(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error calculating version: %w", err)
+		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		return shortSha, nil
 	}
 
 	seq := version2.FindLatestVersionSequence(shortSha, artifacts)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -81,8 +81,13 @@ func getCurrentVersion(ctx context.Context, pusher app.Pusher) (string, string, 
 		return shortSha, "", fmt.Errorf("error calculating version: %w", err)
 	}
 
-	if seq == 0 {
+	// no existing deploys found for this commitSha
+	if seq == -1 {
 		return shortSha, "", fmt.Errorf("no artifacts found for this commit SHA (%s) - you must perform a successful push before deploying", shortSha)
+	}
+	// only one deploy found for this commitSha, so we don't need to append a sequence
+	if seq == 0 {
+		return shortSha, shortSha, nil
 	}
 	return shortSha, fmt.Sprintf("%s-%d", shortSha, seq), nil
 }

--- a/cmd/flag_app_version.go
+++ b/cmd/flag_app_version.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "github.com/urfave/cli/v2"
+import (
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/nullstone.v0/vcs"
+)
 
 var AppVersionFlag = &cli.StringFlag{
 	Name: "version",
@@ -12,8 +15,8 @@ func DetectAppVersion(c *cli.Context) string {
 	version := c.String("version")
 	if version == "" {
 		// If user does not specify a version, use HEAD commit sha
-		if hash, err := getCurrentCommitSha(); err == nil && len(hash) >= 8 {
-			return hash[0:8]
+		if hash, err := vcs.GetCurrentCommitSha(); err == nil && len(hash) >= 7 {
+			return hash[0:7]
 		}
 	}
 	return version

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -34,9 +34,10 @@ var Launch = func(providers app.Providers) *cli.Command {
 					return err
 				}
 
+				commitSha := ""
 				if version == "" {
 					fmt.Fprintf(osWriters.Stderr(), "No version specified. Defaulting version based on current git commit sha...\n")
-					version, err = calcNewVersion(ctx, pusher)
+					commitSha, version, err = calcNewVersion(ctx, pusher)
 					if err != nil {
 						return err
 					}
@@ -49,7 +50,7 @@ var Launch = func(providers app.Providers) *cli.Command {
 				}
 
 				fmt.Fprintln(osWriters.Stderr(), "Creating deploy...")
-				deploy, err := CreateDeploy(cfg, appDetails, version)
+				deploy, err := CreateDeploy(cfg, appDetails, commitSha, version)
 				if err != nil {
 					return err
 				}

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/mod/semver"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/nullstone.v0/modules"
+	"gopkg.in/nullstone-io/nullstone.v0/vcs"
 	"os"
 	"path"
 	"strings"
@@ -144,8 +145,8 @@ var ModulesPublish = &cli.Command{
 					return err
 				}
 				var commitSha string
-				if hash, err := getCurrentCommitSha(); err == nil && len(hash) >= 8 {
-					commitSha = hash[0:8]
+				if hash, err := vcs.GetCurrentCommitSha(); err == nil && len(hash) >= 7 {
+					commitSha = hash[0:7]
 				} else {
 					return fmt.Errorf("Using --version=next-build requires a git repository with a commit. Cannot find commit SHA: %w", err)
 				}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -69,7 +69,8 @@ func calcNewVersion(ctx context.Context, pusher app.Pusher) (string, error) {
 
 	artifacts, err := pusher.ListArtifactVersions(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error calculating version: %w", err)
+		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		return shortSha, nil
 	}
 
 	seq := version2.FindLatestVersionSequence(shortSha, artifacts)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -8,6 +8,9 @@ import (
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/vcs"
+	version2 "gopkg.in/nullstone-io/nullstone.v0/version"
+	"os"
 )
 
 // Push command performs a docker push to an authenticated image registry configured against an app/container
@@ -26,36 +29,75 @@ var Push = func(providers app.Providers) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			return AppWorkspaceAction(c, func(ctx context.Context, cfg api.Config, appDetails app.Details) error {
-				source, version := c.String("source"), DetectAppVersion(c)
-				osWriters := logging.StandardOsWriters{}
-				provider := providers.FindFactory(*appDetails.Module)
-				if provider == nil {
-					return fmt.Errorf("push is not supported for this app")
+				source, version := c.String("source"), c.String("version")
+
+				pusher, err := getPusher(providers, cfg, appDetails)
+				if err != nil {
+					return err
 				}
-				return push(ctx, cfg, appDetails, osWriters, provider, source, version)
+
+				if version == "" {
+					fmt.Fprintf(os.Stderr, "No version specified. Defaulting version based on current git commit sha...\n")
+					version, err = calcNewVersion(ctx, *pusher)
+					if err != nil {
+						return err
+					}
+					fmt.Fprintf(os.Stderr, "Version defaulted to: %s\n", version)
+				}
+
+				return push(ctx, *pusher, source, version)
 			})
 		},
 	}
 }
 
-func push(ctx context.Context, cfg api.Config, appDetails app.Details, osWriters logging.OsWriters, provider *app.Provider, source, version string) error {
-	if provider.NewPusher == nil {
-		return fmt.Errorf("This app does not support push.")
-	}
-	retrieverSource := outputs.ApiRetrieverSource{Config: cfg}
-	pusher, err := provider.NewPusher(osWriters, retrieverSource, appDetails)
-	if err != nil {
-		return fmt.Errorf("error creating app pusher: %w", err)
-	} else if pusher == nil {
-		return fmt.Errorf("this CLI does not support application category=%s, type=%s", appDetails.Module.Category, appDetails.Module.Type)
+func getPusher(providers app.Providers, cfg api.Config, appDetails app.Details) (*app.Pusher, error) {
+	osWriters := logging.StandardOsWriters{}
+	provider := providers.FindFactory(*appDetails.Module)
+	if provider == nil {
+		return nil, fmt.Errorf("push is not supported for this app")
 	}
 
-	stdout := osWriters.Stdout()
-	fmt.Fprintln(stdout, "Pushing app artifact...")
+	if provider.NewPusher == nil {
+		return nil, fmt.Errorf("this app does not support push")
+	}
+	retriever := outputs.ApiRetrieverSource{Config: cfg}
+	pusher, err := provider.NewPusher(osWriters, retriever, appDetails)
+	if err != nil {
+		return nil, fmt.Errorf("error creating app pusher: %w", err)
+	} else if pusher == nil {
+		return nil, fmt.Errorf("this application category=%s, type=%s does not support push", appDetails.Module.Category, appDetails.Module.Type)
+	}
+	return &pusher, nil
+}
+
+func calcNewVersion(ctx context.Context, pusher app.Pusher) (string, error) {
+	shortSha, err := vcs.GetCurrentShortCommitSha()
+	if err != nil {
+		return "", fmt.Errorf("error calculating version: %w", err)
+	}
+
+	artifacts, err := pusher.ListArtifacts(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error calculating version: %w", err)
+	}
+
+	seq := version2.FindLatestVersionSequence(shortSha, artifacts)
+	if err != nil {
+		return "", fmt.Errorf("error calculating version: %w", err)
+	}
+
+	version := fmt.Sprintf("%s-%d", shortSha, seq+1)
+
+	return version, nil
+}
+
+func push(ctx context.Context, pusher app.Pusher, source, version string) error {
+	fmt.Fprintln(os.Stderr, "Pushing app artifact...")
 	if err := pusher.Push(ctx, source, version); err != nil {
 		return fmt.Errorf("error pushing artifact: %w", err)
 	}
-	fmt.Fprintln(stdout, "App artifact pushed.")
-	fmt.Fprintln(stdout, "")
+	fmt.Fprintln(os.Stderr, "App artifact pushed.")
+	fmt.Fprintln(os.Stderr, "")
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -78,7 +78,13 @@ func calcNewVersion(ctx context.Context, pusher app.Pusher) (string, string, err
 		return shortSha, "", fmt.Errorf("error calculating version: %w", err)
 	}
 
-	version := fmt.Sprintf("%s-%d", shortSha, seq+1)
+	version := shortSha
+	// -1 means we didn't find any existing deploys for this commitSha
+	// and we will just use the shortSha as the version
+	// otherwise we will append the sequence number
+	if seq > -1 {
+		version = fmt.Sprintf("%s-%d", shortSha, seq+1)
+	}
 
 	return shortSha, version, nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -49,6 +49,7 @@ func push(ctx context.Context, cfg api.Config, appDetails app.Details, osWriters
 	} else if pusher == nil {
 		return fmt.Errorf("this CLI does not support application category=%s, type=%s", appDetails.Module.Category, appDetails.Module.Type)
 	}
+
 	stdout := osWriters.Stdout()
 	fmt.Fprintln(stdout, "Pushing app artifact...")
 	if err := pusher.Push(ctx, source, version); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240119221247-7d13771b44f8
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module gopkg.in/nullstone-io/nullstone.v0
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
-	github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784
+	github.com/nullstone-io/deployment-sdk v0.0.0-20240216035521-cd2ba1687887
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240216035328-a053bf05f3d7
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
-	github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb
+	github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module gopkg.in/nullstone-io/nullstone.v0
 
 go 1.21
 
+toolchain go1.21.3
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.37.0
@@ -10,7 +12,7 @@ require (
 	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
-	github.com/nullstone-io/deployment-sdk v0.0.0-20240119221556-8aa8a346063f
+	github.com/nullstone-io/deployment-sdk v0.0.0-20240209040346-b0362626d42f
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.8.4
@@ -23,6 +25,8 @@ require (
 	k8s.io/client-go v0.27.2
 	k8s.io/kubectl v0.27.1
 )
+
+replace github.com/nullstone-io/deployment-sdk => ../deployment-sdk
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
-	github.com/nullstone-io/deployment-sdk v0.0.0-20240209040346-b0362626d42f
+	github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.8.4
@@ -25,8 +25,6 @@ require (
 	k8s.io/client-go v0.27.2
 	k8s.io/kubectl v0.27.1
 )
-
-replace github.com/nullstone-io/deployment-sdk => ../deployment-sdk
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784 h1:Z44OF31Fkny9ZFvb6BT0g1IA5Sjh1rPL0TziJ0gFMzI=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240216035521-cd2ba1687887 h1:x8+lDD7PGvLCZnfbjP3Z9Im9Tk1y4gl4qnFokgp8ae4=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240216035521-cd2ba1687887/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -1427,8 +1427,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6 h1:L6k73HiASAkYJXbe2HnaJnKIctuRD+mETcksoBVNfo8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6/go.mod h1:J6xI0PhiSwVeLHdtkZz94BNxK7G+MlqMG5RmZcTXPtI=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240216035328-a053bf05f3d7 h1:8RtK9yUtFB0k0aH6QtlH1hcy8aY0h2hBdfsAmBDqq50=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240216035328-a053bf05f3d7/go.mod h1:J6xI0PhiSwVeLHdtkZz94BNxK7G+MlqMG5RmZcTXPtI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb h1:iCliOaSOHBKwrMMnIkz8HVZKWWm0RHcyApjCQ+hClBI=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240119221556-8aa8a346063f h1:js7u3XNUc+0N4fEF7XkLY21lkSn93neQhdcVmPeVyvM=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240119221556-8aa8a346063f/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -1427,8 +1427,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240119221247-7d13771b44f8 h1:0YP+MjLThxsq7kpdESGF9NZr+SWuZ9/igmnMF1LKBBs=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240119221247-7d13771b44f8/go.mod h1:J6xI0PhiSwVeLHdtkZz94BNxK7G+MlqMG5RmZcTXPtI=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6 h1:L6k73HiASAkYJXbe2HnaJnKIctuRD+mETcksoBVNfo8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240212212820-a965121936f6/go.mod h1:J6xI0PhiSwVeLHdtkZz94BNxK7G+MlqMG5RmZcTXPtI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb h1:iCliOaSOHBKwrMMnIkz8HVZKWWm0RHcyApjCQ+hClBI=
-github.com/nullstone-io/deployment-sdk v0.0.0-20240211200630-a263af44ccfb/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784 h1:Z44OF31Fkny9ZFvb6BT0g1IA5Sjh1rPL0TziJ0gFMzI=
+github.com/nullstone-io/deployment-sdk v0.0.0-20240212161426-e73f134ed784/go.mod h1:CMHFzZIZ8NY48I+Gi/+/8/l8fLRr2ZhhogLY4wgggHw=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/vcs/get_commit_sha.go
+++ b/vcs/get_commit_sha.go
@@ -5,10 +5,11 @@ func GetCurrentShortCommitSha() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(sha) < 7 {
-		return "", nil
+	maxLength := 7
+	if len(sha) < maxLength {
+		maxLength = len(sha)
 	}
-	return sha[0:7], nil
+	return sha[0:maxLength], nil
 }
 
 func GetCurrentCommitSha() (string, error) {

--- a/vcs/get_commit_sha.go
+++ b/vcs/get_commit_sha.go
@@ -1,5 +1,16 @@
 package vcs
 
+func GetCurrentShortCommitSha() (string, error) {
+	sha, err := GetCurrentCommitSha()
+	if err != nil {
+		return "", err
+	}
+	if len(sha) < 7 {
+		return "", nil
+	}
+	return sha[0:7], nil
+}
+
 func GetCurrentCommitSha() (string, error) {
 	repo, err := GetGitRepo()
 	if err != nil {

--- a/vcs/get_commit_sha.go
+++ b/vcs/get_commit_sha.go
@@ -1,9 +1,7 @@
-package cmd
+package vcs
 
-import "gopkg.in/nullstone-io/nullstone.v0/vcs"
-
-func getCurrentCommitSha() (string, error) {
-	repo, err := vcs.GetGitRepo()
+func GetCurrentCommitSha() (string, error) {
+	repo, err := GetGitRepo()
 	if err != nil {
 		return "", err
 	}

--- a/version/find_latest_version.go
+++ b/version/find_latest_version.go
@@ -11,10 +11,19 @@ import (
 //	this will return the largest sequence number found
 //	if no matches are found, this will return 0
 func FindLatestVersionSequence(shortSha string, artifacts []string) int {
-	sequence := 0
+	sequence := -1
 	for _, artifact := range artifacts {
 		// if we find an artifact with the same shortSha, we will increase the sequence if it is the largest
-		if strings.HasPrefix(artifact, shortSha) {
+		if artifact == shortSha || strings.HasPrefix(artifact, shortSha) {
+			// if it is an exact match, we have found the first deploy (which doesn't have a sequence appended)
+			if artifact == shortSha {
+				seq := 0
+				if seq > sequence {
+					sequence = seq
+				}
+				continue
+			}
+
 			// split the sha and sequence
 			parts := strings.Split(artifact, "-")
 			// if we don't get exactly 2 parts, this isn't the correct format so we will ignore

--- a/version/find_latest_version.go
+++ b/version/find_latest_version.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"strconv"
+	"strings"
+)
+
+// FindLatestVersionSequence takes the provided shortSha and finds any versions in the list of artifacts
+//
+//	a match is any artifact that starts with the shortSha
+//	this will return the largest sequence number found
+//	if no matches are found, this will return 0
+func FindLatestVersionSequence(shortSha string, artifacts []string) int {
+	sequence := 0
+	for _, artifact := range artifacts {
+		// if we find an artifact with the same shortSha, we will increase the sequence if it is the largest
+		if strings.HasPrefix(artifact, shortSha) {
+			// split the sha and sequence
+			parts := strings.Split(artifact, "-")
+			// if we don't get exactly 2 parts, this isn't the correct format so we will ignore
+			if len(parts) != 2 {
+				continue
+			}
+			sequenceStr := parts[1]
+			seq, err := strconv.Atoi(sequenceStr)
+			// if the second part isn't a number, this isn't the correct format so we will ignore
+			if err != nil {
+				continue
+			}
+			// if the sequence is larger than the current sequence, we will update the sequence
+			if seq > sequence {
+				sequence = seq
+			}
+		}
+	}
+
+	return sequence
+}

--- a/version/find_latest_version_test.go
+++ b/version/find_latest_version_test.go
@@ -1,0 +1,29 @@
+package version
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFindLatestVersionSequence(t *testing.T) {
+	t.Run("no artifacts", func(t *testing.T) {
+		artifacts := []string{}
+		sequence := FindLatestVersionSequence("8b0ce41", artifacts)
+		assert.Equal(t, -1, sequence)
+	})
+	t.Run("one artifact", func(t *testing.T) {
+		artifacts := []string{"8b0ce41"}
+		sequence := FindLatestVersionSequence("8b0ce41", artifacts)
+		assert.Equal(t, 0, sequence)
+	})
+	t.Run("multiple sequences", func(t *testing.T) {
+		artifacts := []string{"8b0ce41", "8b0ce41-1", "8b0ce41-2"}
+		sequence := FindLatestVersionSequence("8b0ce41", artifacts)
+		assert.Equal(t, 2, sequence)
+	})
+	t.Run("multiple artifact roots, multiple sequences", func(t *testing.T) {
+		artifacts := []string{"8b0ce41", "8b0ce41-1", "aafb1de-1", "aafb1de-2", "aafb1de-3"}
+		sequence := FindLatestVersionSequence("8b0ce41", artifacts)
+		assert.Equal(t, 1, sequence)
+	})
+}


### PR DESCRIPTION
This PR updates the push, deploy, and launch commands to take into account whether artifacts have already been uploaded for a given commit sha. If so, a sequence number is appended on the end of the commit sha to form the version.

There were also some updates in the deployment-sdk requiring a outputs.ApiRetrieverSource. This code has been refactored to become compatible with this change.