### PR TITLE
Sanitizing env name in `envs new` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.114 (Feb 15, 2024)
+* Sanitizing environment name before creating in `envs new` command.
+
 # 0.0.113 (Feb 14, 2024)
 * Restoring `NULLSTONE_API_KEY` usage when running CLI commands.
 

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -316,10 +316,12 @@ func createPreviewEnv(client api.Client, stackId int64, name string) error {
 }
 
 var EnvsUp = &cli.Command{
-	Name:        "up",
-	Description: "Launches an entire environment including all of its apps. This command can be used to stand up an entire preview environment.",
-	Usage:       "Launch an entire environment",
-	UsageText:   "nullstone envs up --stack=<stack> --env=<env>",
+	Name: "up",
+	Description: `Launches an entire environment including all of its apps. 
+This command can be used to stand up an entire preview environment.
+This will only build/deploy apps that have auto-deploy enabled.`,
+	Usage:     "Launch an entire environment",
+	UsageText: "nullstone envs up --stack=<stack> --env=<env>",
 	Flags: []cli.Flag{
 		StackRequiredFlag,
 		EnvFlag,
@@ -335,10 +337,11 @@ var EnvsUp = &cli.Command{
 }
 
 var EnvsDown = &cli.Command{
-	Name:        "down",
-	Description: "Destroys all the apps in an environment and all their dependent infrastructure. This command is useful for tearing down preview environments once you are finished with them.",
-	Usage:       "Destroy an entire environment",
-	UsageText:   "nullstone envs down --stack=<stack> --env=<env>",
+	Name: "down",
+	Description: `Destroys all infrastructure in an environment. 
+This command is useful for tearing down preview environments once you are finished with them.`,
+	Usage:     "Destroy an entire environment",
+	UsageText: "nullstone envs down --stack=<stack> --env=<env>",
 	Flags: []cli.Flag{
 		StackRequiredFlag,
 		EnvFlag,

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -157,6 +157,7 @@ var invalidCharsMatchRe = regexp.MustCompile(`[^a-z\d\-]`) // match characters t
 
 // sanitizeEnvName allows a user to specify --name during `envs new` without worrying about sanitizing bad input
 func sanitizeEnvName(input string) string {
+	// https://go.dev/play/p/agF5MlgKpLN
 	// 1. Convert uppercase to lowercase
 	// 2. Convert all special characters to '-'
 	// 3. Collapse double hyphens into single
@@ -172,8 +173,10 @@ func sanitizeEnvName(input string) string {
 		// It's common to use <branch>-<pr_id>
 		// We're going to split on the last '-', and trim before that '-'
 		// If there is no '-', we will have to trim off the entire string
-		if before, after, found := strings.Cut(sanitized, "-"); found {
-			sanitized = fmt.Sprintf("%s-%s", before[:32-1-len(after)], after)
+		if lastIndex := strings.LastIndex(sanitized, "-"); lastIndex > -1 {
+			after := sanitized[lastIndex+1:]
+			before := sanitized[:32-1-len(after)]
+			sanitized = fmt.Sprintf("%s-%s", before, after)
 		} else {
 			sanitized = sanitized[0:32]
 		}

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -105,7 +105,7 @@ var EnvsNew = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "name",
-			Usage:    "Provide a name for this new environment",
+			Usage:    "Provide a name for this new environment. If creating a preview environment, we recommend `<branch>-<pull_request_id>`.",
 			Required: true,
 		},
 		StackRequiredFlag,
@@ -143,6 +143,7 @@ var EnvsNew = &cli.Command{
 				return fmt.Errorf("stack %q does not exist", stackName)
 			}
 
+			name = sanitizeEnvName(name)
 			if preview {
 				return createPreviewEnv(client, stack.Id, name)
 			} else {


### PR DESCRIPTION
I updated `envs new` command to sanitize input from `--name`.
This follows the same algorithm we use to create preview envs automatically.
While the user is recommended to use `<branch>-<pr_id>`, the algorithm does not enforce it.