### PR TITLE
B/commit info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.122 (Sep 30, 2024)
 * Added `commitSha` when created deploy so that Nullstone can add commit info to deploy activity.
+* Added detection of automation tool (e.g. CircleCI, Github Actions, Gitlab, etc.) when creating deploy.
 
 # 0.0.121 (Jul 11, 2024)
 * Updated CLI commands (`launch`, `deploy`, `plan`, `apply`, `up`, `envs up`, `envs down`) to interop with workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.122 (Sep 30, 2024)
+* Added `commitSha` when created deploy so that Nullstone can add commit info to deploy activity.
+
 # 0.0.121 (Jul 11, 2024)
 * Updated CLI commands (`launch`, `deploy`, `plan`, `apply`, `up`, `envs up`, `envs down`) to interop with workflows.
 

--- a/cmd/create_deploy.go
+++ b/cmd/create_deploy.go
@@ -8,20 +8,6 @@ import (
 	"os"
 )
 
-const (
-	AutomationToolCircleCI       = "circleci"
-	AutomationToolGithubActions  = "github-actions"
-	AutomationToolGitlab         = "gitlab"
-	AutomationToolBitbucket      = "bitbucket"
-	AutomationToolJenkins        = "jenkins"
-	AutomationToolTravis         = "travis"
-	AutomationToolAzurePipelines = "azure-pipeline"
-	AutomationToolAppveyor       = "appveyor"
-	AutomationToolTeamCity       = "team-city"
-	AutomationToolCodeship       = "codeship"
-	AutomationToolSemaphore      = "semaphore"
-)
-
 func CreateDeploy(nsConfig api.Config, appDetails app.Details, commitSha, version string) (*api.DeployCreateResult, error) {
 	ctx := context.TODO()
 	client := api.Client{Config: nsConfig}
@@ -42,38 +28,38 @@ func CreateDeploy(nsConfig api.Config, appDetails app.Details, commitSha, versio
 
 func detectAutomationTool() string {
 	if os.Getenv("CIRCLECI") != "" {
-		return AutomationToolCircleCI
+		return api.AutomationToolCircleCI
 	}
 	if os.Getenv("GITHUB_ACTIONS") != "" {
-		return AutomationToolGithubActions
+		return api.AutomationToolGithubActions
 	}
 	if os.Getenv("GITLAB_CI") != "" {
-		return AutomationToolGitlab
+		return api.AutomationToolGitlab
 	}
 	if os.Getenv("BITBUCKET_PIPELINES") != "" {
-		return AutomationToolBitbucket
+		return api.AutomationToolBitbucket
 	}
 	if os.Getenv("JENKINS_URL") != "" {
-		return AutomationToolJenkins
+		return api.AutomationToolJenkins
 	}
 	if os.Getenv("TRAVIS") != "" {
-		return AutomationToolTravis
+		return api.AutomationToolTravis
 	}
 	if os.Getenv("TF_BUILD") != "" {
 		// TF_BUILD is not referring to Terraform, it's legacy from the original system called "Team Foundation"
-		return AutomationToolAzurePipelines
+		return api.AutomationToolAzurePipelines
 	}
 	if os.Getenv("APPVEYOR") != "" {
-		return AutomationToolAppveyor
+		return api.AutomationToolAppveyor
 	}
 	if os.Getenv("TEAMCITY_VERSION") != "" {
-		return AutomationToolTeamCity
+		return api.AutomationToolTeamCity
 	}
 	if os.Getenv("CI_NAME") != "codeship" {
-		return AutomationToolCodeship
+		return api.AutomationToolCodeship
 	}
 	if os.Getenv("SEMAPHORE") != "" {
-		return AutomationToolSemaphore
+		return api.AutomationToolSemaphore
 	}
 	return ""
 }

--- a/cmd/create_deploy.go
+++ b/cmd/create_deploy.go
@@ -5,15 +5,31 @@ import (
 	"fmt"
 	"github.com/nullstone-io/deployment-sdk/app"
 	"gopkg.in/nullstone-io/go-api-client.v0"
+	"os"
+)
+
+const (
+	AutomationToolCircleCI       = "circleci"
+	AutomationToolGithubActions  = "github-actions"
+	AutomationToolGitlab         = "gitlab"
+	AutomationToolBitbucket      = "bitbucket"
+	AutomationToolJenkins        = "jenkins"
+	AutomationToolTravis         = "travis"
+	AutomationToolAzurePipelines = "azure-pipeline"
+	AutomationToolAppveyor       = "appveyor"
+	AutomationToolTeamCity       = "team-city"
+	AutomationToolCodeship       = "codeship"
+	AutomationToolSemaphore      = "semaphore"
 )
 
 func CreateDeploy(nsConfig api.Config, appDetails app.Details, commitSha, version string) (*api.DeployCreateResult, error) {
 	ctx := context.TODO()
 	client := api.Client{Config: nsConfig}
 	payload := api.DeployCreatePayload{
-		FromSource: false,
-		Version:    version,
-		CommitSha:  commitSha,
+		FromSource:     false,
+		Version:        version,
+		CommitSha:      commitSha,
+		AutomationTool: detectAutomationTool(),
 	}
 	result, err := client.Deploys().Create(ctx, appDetails.App.StackId, appDetails.App.Id, appDetails.Env.Id, payload)
 	if err != nil {
@@ -22,4 +38,42 @@ func CreateDeploy(nsConfig api.Config, appDetails app.Details, commitSha, versio
 		return nil, fmt.Errorf("unable to create deploy")
 	}
 	return result, nil
+}
+
+func detectAutomationTool() string {
+	if os.Getenv("CIRCLECI") != "" {
+		return AutomationToolCircleCI
+	}
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		return AutomationToolGithubActions
+	}
+	if os.Getenv("GITLAB_CI") != "" {
+		return AutomationToolGitlab
+	}
+	if os.Getenv("BITBUCKET_PIPELINES") != "" {
+		return AutomationToolBitbucket
+	}
+	if os.Getenv("JENKINS_URL") != "" {
+		return AutomationToolJenkins
+	}
+	if os.Getenv("TRAVIS") != "" {
+		return AutomationToolTravis
+	}
+	if os.Getenv("TF_BUILD") != "" {
+		// TF_BUILD is not referring to Terraform, it's legacy from the original system called "Team Foundation"
+		return AutomationToolAzurePipelines
+	}
+	if os.Getenv("APPVEYOR") != "" {
+		return AutomationToolAppveyor
+	}
+	if os.Getenv("TEAMCITY_VERSION") != "" {
+		return AutomationToolTeamCity
+	}
+	if os.Getenv("CI_NAME") != "codeship" {
+		return AutomationToolCodeship
+	}
+	if os.Getenv("SEMAPHORE") != "" {
+		return AutomationToolSemaphore
+	}
+	return ""
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
+	version2 "gopkg.in/nullstone-io/nullstone.v0/version"
 )
 
 // Launch command performs push, deploy, and logs
@@ -37,10 +38,12 @@ var Launch = func(providers app.Providers) *cli.Command {
 				commitSha := ""
 				if version == "" {
 					fmt.Fprintf(stderr, "No version specified. Defaulting version based on current git commit sha...\n")
-					commitSha, version, err = calcNewVersion(ctx, pusher)
+					info, err := version2.CalcNew(ctx, pusher)
 					if err != nil {
 						return err
 					}
+					version = info.Version
+					commitSha = info.CommitSha
 					fmt.Fprintf(stderr, "Version defaulted to: %s\n", version)
 				}
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240704122801-fa8b47b44f84
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.5.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241001151051-6c276b70fab6
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -1446,8 +1446,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea h1:9FlaJEpu+oeJEjNoSRybrOxkeZ4IGm1jfCO8E5ZBnBU=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb h1:/uwUtzigFhIgsPntlVFwkp6pu4oM0FMIPAaWuR6vaJo=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1446,8 +1446,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e h1:0QMiG7+z9dHFJ0mTzf45Xan5trN7qLkRJ6ova9D44do=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea h1:9FlaJEpu+oeJEjNoSRybrOxkeZ4IGm1jfCO8E5ZBnBU=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930191237-b415cbc691ea/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1446,8 +1446,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb h1:/uwUtzigFhIgsPntlVFwkp6pu4oM0FMIPAaWuR6vaJo=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930203100-c4dd30956bfb/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241001151051-6c276b70fab6 h1:LKTQBJp2Yf1b846xDhwHfRLmCaaVVeMfuO6O73//kXI=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241001151051-6c276b70fab6/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1446,8 +1446,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240704122801-fa8b47b44f84 h1:4O26uSJcXHvkzuSggSqEW5iJZSv/6ep8bg1bJJkkvi4=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240704122801-fa8b47b44f84/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e h1:0QMiG7+z9dHFJ0mTzf45Xan5trN7qLkRJ6ova9D44do=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240930185206-dd669697ab6e/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/version/calc_new.go
+++ b/version/calc_new.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"gopkg.in/nullstone-io/nullstone.v0/vcs"
+)
+
+func CalcNew(ctx context.Context, pusher app.Pusher) (Info, error) {
+	result := Info{}
+	var err error
+	if result.CommitSha, err = vcs.GetCurrentCommitSha(); err != nil {
+		return Info{}, fmt.Errorf("error calculating version: %w", err)
+	}
+	result.Version = result.ShortCommitSha()
+
+	artifacts, err := pusher.ListArtifactVersions(ctx)
+	if err != nil {
+		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		return result, nil
+	}
+
+	seq := FindLatestVersionSequence(result.ShortCommitSha(), artifacts)
+	if err != nil {
+		result.Version = ""
+		return result, fmt.Errorf("error calculating version: %w", err)
+	}
+
+	// -1 means we didn't find any existing deploys for this commitSha
+	// and we will just use the shortSha as the version
+	// otherwise we will append the sequence number
+	if seq > -1 {
+		result.Version = fmt.Sprintf("%s-%d", result.ShortCommitSha(), seq+1)
+	}
+
+	return result, nil
+}

--- a/version/calc_new.go
+++ b/version/calc_new.go
@@ -13,11 +13,11 @@ func CalcNew(ctx context.Context, pusher app.Pusher) (Info, error) {
 	if result.CommitSha, err = vcs.GetCurrentCommitSha(); err != nil {
 		return Info{}, fmt.Errorf("error calculating version: %w", err)
 	}
-	result.Version = result.ShortCommitSha()
 
 	artifacts, err := pusher.ListArtifactVersions(ctx)
 	if err != nil {
 		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		result.Version = result.ShortCommitSha()
 		return result, nil
 	}
 
@@ -34,5 +34,6 @@ func CalcNew(ctx context.Context, pusher app.Pusher) (Info, error) {
 		result.Version = fmt.Sprintf("%s-%d", result.ShortCommitSha(), seq+1)
 	}
 
+	result.Version = result.ShortCommitSha()
 	return result, nil
 }

--- a/version/get_current.go
+++ b/version/get_current.go
@@ -37,7 +37,7 @@ func GetCurrent(ctx context.Context, pusher app.Pusher) (Info, error) {
 		result.Version = result.ShortCommitSha()
 		return result, nil
 	}
-	
+
 	result.Version = fmt.Sprintf("%s-%d", result.ShortCommitSha(), seq)
 	return result, nil
 }

--- a/version/get_current.go
+++ b/version/get_current.go
@@ -13,11 +13,11 @@ func GetCurrent(ctx context.Context, pusher app.Pusher) (Info, error) {
 	if result.CommitSha, err = vcs.GetCurrentCommitSha(); err != nil {
 		return Info{}, fmt.Errorf("error calculating version: %w", err)
 	}
-	result.Version = result.ShortCommitSha()
 
 	artifacts, err := pusher.ListArtifactVersions(ctx)
 	if err != nil {
 		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		result.Version = result.ShortCommitSha()
 		return result, nil
 	}
 
@@ -34,8 +34,10 @@ func GetCurrent(ctx context.Context, pusher app.Pusher) (Info, error) {
 	}
 	// only one deploy found for this commitSha, so we don't need to append a sequence
 	if seq == 0 {
+		result.Version = result.ShortCommitSha()
 		return result, nil
 	}
+	
 	result.Version = fmt.Sprintf("%s-%d", result.ShortCommitSha(), seq)
 	return result, nil
 }

--- a/version/get_current.go
+++ b/version/get_current.go
@@ -1,0 +1,41 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"gopkg.in/nullstone-io/nullstone.v0/vcs"
+)
+
+func GetCurrent(ctx context.Context, pusher app.Pusher) (Info, error) {
+	result := Info{}
+	var err error
+	if result.CommitSha, err = vcs.GetCurrentCommitSha(); err != nil {
+		return Info{}, fmt.Errorf("error calculating version: %w", err)
+	}
+	result.Version = result.ShortCommitSha()
+
+	artifacts, err := pusher.ListArtifactVersions(ctx)
+	if err != nil {
+		// if we aren't able to pull the list of artifact versions, we can just use the short sha as the fallback
+		return result, nil
+	}
+
+	seq := FindLatestVersionSequence(result.ShortCommitSha(), artifacts)
+	if err != nil {
+		result.Version = ""
+		return result, fmt.Errorf("error calculating version: %w", err)
+	}
+
+	// no existing deploys found for this commitSha
+	if seq == -1 {
+		result.Version = ""
+		return result, fmt.Errorf("no artifacts found for this commit SHA (%s) - you must perform a successful push before deploying", result.ShortCommitSha())
+	}
+	// only one deploy found for this commitSha, so we don't need to append a sequence
+	if seq == 0 {
+		return result, nil
+	}
+	result.Version = fmt.Sprintf("%s-%d", result.ShortCommitSha(), seq)
+	return result, nil
+}

--- a/version/info.go
+++ b/version/info.go
@@ -1,0 +1,14 @@
+package version
+
+type Info struct {
+	CommitSha string
+	Version   string
+}
+
+func (i Info) ShortCommitSha() string {
+	maxLength := 7
+	if len(i.CommitSha) < maxLength {
+		maxLength = len(i.CommitSha)
+	}
+	return i.CommitSha[0:maxLength]
+}


### PR DESCRIPTION
This fixes an issue where we transmitted the short commit sha instead of the full commit sha to the server when creating a deploy.

This also detects the CI tool and adds `AutomationTool` to Create deploy payload.

This relies on https://github.com/nullstone-io/go-api-client/pull/94