### PR TITLE
Refresh intent workflow to improve reliability of streaming deploy logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.134 (Dec 17, 2024)
+* Improve reliability of streaming deploy logs when performing a deployment.
+
 # 0.0.133 (Dec 11, 2024)
 * Added ability for users with `software_engineer` to access logs, metrics, and status.
 * Added support for GCP static sites.

--- a/cmd/wait_for.go
+++ b/cmd/wait_for.go
@@ -22,6 +22,12 @@ func waitForRunningIntentWorkflow(ctx context.Context, cfg api.Config, iw types.
 	for {
 		switch cur.Status {
 		case types.IntentWorkflowStatusRunning:
+			updated, err := client.IntentWorkflows().Get(ctx, iw.StackId, iw.Id)
+			if err != nil {
+				return cur, fmt.Errorf("error waiting for deployment: %w", err)
+			} else if updated != nil {
+				cur = *updated
+			}
 			return cur, nil
 		case types.IntentWorkflowStatusCompleted:
 			return cur, nil


### PR DESCRIPTION
This fixes an issue where the CLI would not stream the deploy logs after issuing `nullstone deploy`.

I suspect that there is a sporadic issue streaming websocket updates for intent workflows.
This fix attempts to improve reliability by fetching a fresh update after status transitions into `running`.