### PR TITLE
F/2117/gke job run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.135 (Unreleased)
+* Added `nullstone run` command that allows you to a start a new job/task.
+
 # 0.0.134 (Dec 17, 2024)
 * Improve reliability of streaming deploy logs when performing a deployment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.135 (Unreleased)
 * Added `nullstone run` command that allows you to a start a new job/task.
+* Added support for `nullstone run` to ECS/Fargate tasks and GKE jobs.
 
 # 0.0.134 (Dec 17, 2024)
 * Improve reliability of streaming deploy logs when performing a deployment.

--- a/admin/remoter.go
+++ b/admin/remoter.go
@@ -21,6 +21,14 @@ type RemoteOptions struct {
 	LogEmitter   app.LogEmitter
 }
 
+type RunOptions struct {
+	// Container represents the specific container name to execute against in the k8s pod/ecs task
+	Container   string
+	Username    string
+	LogStreamer app.LogStreamer
+	LogEmitter  app.LogEmitter
+}
+
 type Remoter interface {
 	// Exec allows a user to execute a command (usually tunneling) into a running service
 	// This only makes sense for container-based providers
@@ -28,4 +36,7 @@ type Remoter interface {
 
 	// Ssh allows a user to SSH into a running service
 	Ssh(ctx context.Context, options RemoteOptions) error
+
+	// Run starts a new job/task and executes a command
+	Run(ctx context.Context, options RunOptions, cmd []string) error
 }

--- a/app/build.go
+++ b/app/build.go
@@ -48,6 +48,7 @@ func Build() *cli.App {
 		cmd.Status(adminProviders),
 		cmd.Exec(appProviders, adminProviders),
 		cmd.Ssh(adminProviders),
+		cmd.Run(appProviders, adminProviders),
 		cmd.Profile,
 	}
 	sort.Sort(cli.CommandsByName(cliApp.Commands))

--- a/aws/beanstalk/remoter.go
+++ b/aws/beanstalk/remoter.go
@@ -10,6 +10,10 @@ import (
 	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
 )
 
+var (
+	_ admin.Remoter = Remoter{}
+)
+
 func NewRemoter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (admin.Remoter, error) {
 	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
@@ -50,6 +54,10 @@ func (r Remoter) Ssh(ctx context.Context, options admin.RemoteOptions) error {
 		return err
 	}
 	return ssm.StartEc2Session(ctx, r.Infra.AdminerConfig(), r.Infra.Region, instanceId, parameters)
+}
+
+func (r Remoter) Run(ctx context.Context, options admin.RunOptions, cmd []string) error {
+	return fmt.Errorf("`run` is not supported for Beanstalk yet")
 }
 
 func (r Remoter) getInstanceId(ctx context.Context, options admin.RemoteOptions) (string, error) {

--- a/aws/ec2/remoter.go
+++ b/aws/ec2/remoter.go
@@ -2,11 +2,16 @@ package ec2
 
 import (
 	"context"
+	"fmt"
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"gopkg.in/nullstone-io/nullstone.v0/admin"
 	"gopkg.in/nullstone-io/nullstone.v0/aws/ssm"
+)
+
+var (
+	_ admin.Remoter = Remoter{}
 )
 
 func NewRemoter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (admin.Remoter, error) {
@@ -41,4 +46,8 @@ func (r Remoter) Ssh(ctx context.Context, options admin.RemoteOptions) error {
 	}
 
 	return ssm.StartEc2Session(ctx, r.Infra.AdminerConfig(), r.Infra.Region, r.Infra.InstanceId, parameters)
+}
+
+func (r Remoter) Run(ctx context.Context, options admin.RunOptions, cmd []string) error {
+	return fmt.Errorf("`run` is not supported for EC2 yet")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,7 @@ import (
 
 var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Command {
 	return &cli.Command{
-		Name:        "Run",
+		Name:        "run",
 		Description: "Starts a new container/serverless for the given Nullstone job/task. ",
 		Usage:       "Starts a new job/task",
 		UsageText:   "nullstone run [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options] [command]",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/admin"
+	"os"
+)
+
+var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Command {
+	return &cli.Command{
+		Name:        "Run",
+		Description: "Starts a new container/serverless for the given Nullstone job/task. ",
+		Usage:       "Starts a new job/task",
+		UsageText:   "nullstone run [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options] [command]",
+		Flags: []cli.Flag{
+			StackFlag,
+			AppFlag,
+			EnvFlag,
+			ContainerFlag,
+		},
+		Action: func(c *cli.Context) error {
+			var cmd []string
+			if c.Args().Present() {
+				cmd = c.Args().Slice()
+			}
+
+			return AppWorkspaceAction(c, func(ctx context.Context, cfg api.Config, appDetails app.Details) error {
+				client := api.Client{Config: cfg}
+				user, err := client.CurrentUser().Get(ctx)
+				if err != nil {
+					return fmt.Errorf("unable to fetch the current user")
+				}
+				if user == nil {
+					return fmt.Errorf("unable to load the current user info")
+				}
+
+				source := outputs.ApiRetrieverSource{Config: cfg}
+
+				logStreamer, err := appProviders.FindLogStreamer(ctx, logging.StandardOsWriters{}, source, appDetails)
+				if err != nil {
+					return err
+				}
+
+				remoter, err := providers.FindRemoter(ctx, logging.StandardOsWriters{}, source, appDetails)
+				if err != nil {
+					return err
+				}
+				options := admin.RunOptions{
+					Container:   c.String("container"),
+					Username:    user.Name,
+					LogStreamer: logStreamer,
+					LogEmitter:  app.NewWriterLogEmitter(os.Stdout),
+				}
+				return remoter.Run(ctx, options, cmd)
+			})
+		},
+	}
+}

--- a/gcp/gke/outputs.go
+++ b/gcp/gke/outputs.go
@@ -16,9 +16,9 @@ type Outputs struct {
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
 	Deployer          gcp.ServiceAccount `ns:"deployer"`
 	MainContainerName string             `ns:"main_container_name,optional"`
-	// JobDefinition is only specified for a job/task
-	// It is a base64-encoded JSON string that contains the manifest for a job
-	JobDefinition string `ns:"job_definition,optional"`
+	// JobDefinitionName is only specified for a job/task
+	// It refers to a Kubernetes ConfigMap containing the job definition in the "template" field
+	JobDefinitionName string `ns:"job_definition_name,optional"`
 
 	ClusterNamespace ClusterNamespaceOutputs `ns:",connectionContract:cluster-namespace/gcp/k8s:gke"`
 }

--- a/gcp/gke/outputs.go
+++ b/gcp/gke/outputs.go
@@ -16,6 +16,9 @@ type Outputs struct {
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
 	Deployer          gcp.ServiceAccount `ns:"deployer"`
 	MainContainerName string             `ns:"main_container_name,optional"`
+	// JobDefinition is only specified for a job/task
+	// It is a base64-encoded JSON string that contains the manifest for a job
+	JobDefinition string `ns:"job_definition,optional"`
 
 	ClusterNamespace ClusterNamespaceOutputs `ns:",connectionContract:cluster-namespace/gcp/k8s:gke"`
 }

--- a/gcp/gke/remoter.go
+++ b/gcp/gke/remoter.go
@@ -73,8 +73,9 @@ func (r Remoter) Run(ctx context.Context, options admin.RunOptions, cmd []string
 
 	runner := k8s.JobRunner{
 		Namespace:         r.Infra.ServiceNamespace,
+		AppName:           r.Details.App.Name,
 		MainContainerName: r.Infra.MainContainerName,
-		JobDefinition:     r.Infra.JobDefinition,
+		JobDefinitionName: r.Infra.JobDefinitionName,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
 			return gke.CreateKubeConfig(ctx, r.Infra.ClusterNamespace, r.Infra.Deployer)
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module gopkg.in/nullstone-io/nullstone.v0
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.8
+toolchain go1.23.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.0
@@ -13,7 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/nullstone-io/deployment-sdk v0.0.0-20241211140744-31a2fc4195ae
+	github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3
 	github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.28.0
 	golang.org/x/sync v0.8.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241126225657-182d3304f2df
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3
+	github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49
 	github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosuri/uilive v0.0.4
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49
+	github.com/nullstone-io/deployment-sdk v0.0.0-20250106193300-6ff1ee19f6e7
 	github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20241211140744-31a2fc4195ae h1:vKD8ufJlr+DblrdoXLftebLGrobRwaedYMVPMxA7Dew=
-github.com/nullstone-io/deployment-sdk v0.0.0-20241211140744-31a2fc4195ae/go.mod h1:kqj/vI7njyeluNT59Faz0IGhD/h2AZLe+KDczi4XS84=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3 h1:VBgfEHh78KdrQTwpRd4ulIeH4/zDfahy7mo/9Wm+EtU=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3/go.mod h1:44JrdCw01w4meAG+S4kKIZQxatCJa1fiBUxyo+FBzoA=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88 h1:/mXYlqXFwPf0lqBGosvYzregrSL8N0FPaS5dG/Jzar4=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88/go.mod h1:tRZPp425TN0XVAkrkICbZ1EAkmmhNb7ueq7xBLX2goM=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
@@ -1534,8 +1534,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241126225657-182d3304f2df h1:cun7quo+kgvhOvThH2pV9G+E6S78UWri2oufnI1dDaI=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241126225657-182d3304f2df/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805 h1:aGnIBuBJTSE1RQf1YOFVIOUXjpIrUe3AsynUN5TOAD8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49 h1:5q56OcuYTzZohIqfGfILviabgsebrf7pFzvEMbm6DUc=
-github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49/go.mod h1:44JrdCw01w4meAG+S4kKIZQxatCJa1fiBUxyo+FBzoA=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250106193300-6ff1ee19f6e7 h1:m4nhAsZv4G+DLalvjVUvLuzF2zehfgKb7tvZJocc8pk=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250106193300-6ff1ee19f6e7/go.mod h1:44JrdCw01w4meAG+S4kKIZQxatCJa1fiBUxyo+FBzoA=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88 h1:/mXYlqXFwPf0lqBGosvYzregrSL8N0FPaS5dG/Jzar4=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88/go.mod h1:tRZPp425TN0XVAkrkICbZ1EAkmmhNb7ueq7xBLX2goM=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3 h1:VBgfEHh78KdrQTwpRd4ulIeH4/zDfahy7mo/9Wm+EtU=
-github.com/nullstone-io/deployment-sdk v0.0.0-20250104150935-98b03a7618f3/go.mod h1:44JrdCw01w4meAG+S4kKIZQxatCJa1fiBUxyo+FBzoA=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49 h1:5q56OcuYTzZohIqfGfILviabgsebrf7pFzvEMbm6DUc=
+github.com/nullstone-io/deployment-sdk v0.0.0-20250106165400-fe36d56faf49/go.mod h1:44JrdCw01w4meAG+S4kKIZQxatCJa1fiBUxyo+FBzoA=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88 h1:/mXYlqXFwPf0lqBGosvYzregrSL8N0FPaS5dG/Jzar4=
 github.com/nullstone-io/iac v0.0.0-20241105141304-4427f5e31e88/go.mod h1:tRZPp425TN0XVAkrkICbZ1EAkmmhNb7ueq7xBLX2goM=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=

--- a/k8s/job_runner.go
+++ b/k8s/job_runner.go
@@ -1,0 +1,139 @@
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/k8s"
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/nullstone-io/nullstone.v0/admin"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"log"
+	"strings"
+	"time"
+)
+
+const DefaultWatchInterval = 1 * time.Second
+
+type JobRunner struct {
+	Namespace         string
+	MainContainerName string
+	JobDefinition     string
+	NewConfigFn       k8s.NewConfiger
+}
+
+func (r JobRunner) Run(ctx context.Context, options admin.RunOptions, cmd []string) error {
+	decoder := json.NewDecoder(base64.NewDecoder(base64.StdEncoding, strings.NewReader(r.JobDefinition)))
+	var jobDef batchv1.Job
+	if err := decoder.Decode(&jobDef); err != nil {
+		return fmt.Errorf("job_definition from app module outputs is invalid: %w", err)
+	}
+
+	cfg, err := r.NewConfigFn(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("error creating kube client: %w", err)
+	}
+
+	// Add a unique suffix (-{{timestamp}}) to ensure we can `run` repeatedly to create new jobs
+	jobDef.Name = fmt.Sprintf("%s-%d", jobDef.Name, time.Now().Unix())
+
+	// Override `command` if specified by CLI user
+	r.overrideMainContainerCommand(jobDef, cmd)
+
+	job, err := client.BatchV1().Jobs(r.Namespace).Create(ctx, &jobDef, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating job: %w", err)
+	}
+
+	return r.monitorJob(ctx, client, options, job.Name)
+}
+
+func (r JobRunner) monitorJob(ctx context.Context, client *kubernetes.Clientset, options admin.RunOptions, jobName string) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+
+	selector := fmt.Sprintf("job-name=%s", jobName)
+
+	eg.Go(func() error {
+		absoluteTime := time.Now()
+		logStreamOptions := app.LogStreamOptions{
+			StartTime:     &absoluteTime,
+			WatchInterval: time.Duration(0), // this makes sure the log stream doesn't exit until the context is cancelled
+			Emitter:       options.LogEmitter,
+			Selector:      &selector,
+		}
+		return options.LogStreamer.Stream(ctx, logStreamOptions)
+	})
+	eg.Go(func() error {
+		defer cancel()
+		for {
+			// check status of job
+			containerStatus, err := r.getJobContainerStatus(ctx, client, jobName)
+			if err != nil {
+				return err
+			}
+			if containerStatus != nil {
+				if containerStatus.State.Terminated != nil {
+					if exitCode := containerStatus.State.Terminated.ExitCode; exitCode == 0 {
+						log.Printf("Job has completed successfully")
+						return nil
+					} else {
+
+						return fmt.Errorf("Job failed with status code %d\n", exitCode)
+					}
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				switch err := ctx.Err(); {
+				case errors.Is(err, context.Canceled):
+					return fmt.Errorf("cancelled")
+				case errors.Is(err, context.DeadlineExceeded):
+					return fmt.Errorf("timeout")
+				}
+			case <-time.After(DefaultWatchInterval):
+			}
+		}
+	})
+	return eg.Wait()
+}
+
+func (r JobRunner) getJobContainerStatus(ctx context.Context, client *kubernetes.Clientset, jobName string) (*corev1.ContainerStatus, error) {
+	podsResponse, err := client.CoreV1().Pods(r.Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s", jobName)})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range podsResponse.Items {
+		for _, cstatus := range pod.Status.ContainerStatuses {
+			if cstatus.Name == r.MainContainerName || r.MainContainerName == "" {
+				return &cstatus, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (r JobRunner) overrideMainContainerCommand(job batchv1.Job, cmd []string) batchv1.Job {
+	if len(cmd) < 1 {
+		return job
+	}
+	for i, container := range job.Spec.Template.Spec.Containers {
+		if container.Name == r.MainContainerName {
+			container.Command = cmd
+			job.Spec.Template.Spec.Containers[i] = container
+			return job
+		}
+	}
+	return job
+}


### PR DESCRIPTION
This adds the `nullstone run` CLI command.
Initially, this has support for ECS/Fargate and GKE jobs.

This relies on https://github.com/nullstone-io/deployment-sdk/pull/47