### PR TITLE
This updates the CLI after adding Name to Capability

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -35,7 +35,7 @@ var AppsList = &cli.Command{
 		ctx := context.TODO()
 		return ProfileAction(c, func(cfg api.Config) error {
 			client := api.Client{Config: cfg}
-			allApps, err := client.Apps().List(ctx)
+			allApps, err := client.Apps().GlobalList(ctx)
 			if err != nil {
 				return fmt.Errorf("error listing applications: %w", err)
 			}

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -138,16 +138,14 @@ var BlocksNew = &cli.Command{
 				StackId:             stack.Id,
 				Type:                blockTypeFromModuleCategory(module.Category),
 				Name:                name,
+				Repo:                "",
 				ModuleSource:        moduleSource,
 				ModuleSourceVersion: "latest",
 				Connections:         connections,
 			}
 			if strings.HasPrefix(string(module.Category), "app") {
-				app := &types.Application{
-					Block:     *block,
-					Repo:      "",
-					Framework: "other",
-				}
+				app := &types.Application{Block: *block}
+				app.Framework = "other"
 				if newApp, err := client.Apps().Create(ctx, stack.Id, app); err != nil {
 					return err
 				} else if newApp != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.28.0
 	golang.org/x/sync v0.8.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.28.0
 	golang.org/x/sync v0.8.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.28.0
 	golang.org/x/sync v0.8.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -1534,8 +1534,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805 h1:aGnIBuBJTSE1RQf1YOFVIOUXjpIrUe3AsynUN5TOAD8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241213224916-66a525701805/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d h1:wBnhHDWFqAI9vxvk0bnB9/4pIDcB1OiNPJVBMB7ukvY=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1534,8 +1534,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d h1:wBnhHDWFqAI9vxvk0bnB9/4pIDcB1OiNPJVBMB7ukvY=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213141640-7401f448142d/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5 h1:4tRjiEYdb/B85zWnr0RV8Fq0f8kxNBnI8fhUoKKUUPI=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1534,8 +1534,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5 h1:4tRjiEYdb/B85zWnr0RV8Fq0f8kxNBnI8fhUoKKUUPI=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213142316-ef663d8340e5/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d h1:frIlyGuRJkDWLWMVMQyAIMrzWPmr02qYJsvVp/i8yhc=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/k8s/port_forwarder.go
+++ b/k8s/port_forwarder.go
@@ -21,7 +21,7 @@ func NewPortForwarder(cfg *rest.Config, podNamespace, podName string, portMappin
 	if len(portMappings) < 1 {
 		return nil, nil
 	}
-	
+
 	restClient, err := rest.RESTClientFor(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rest client: %w", err)

--- a/workspaces/capabilities.go
+++ b/workspaces/capabilities.go
@@ -77,6 +77,14 @@ func (g CapabilitiesGenerator) Generate(runConfig types.RunConfig) error {
 
 func (g CapabilitiesGenerator) transformCapabilities(runConfig types.RunConfig) (types.CapabilityConfigs, error) {
 	capabilities := runConfig.Capabilities
+	if len(runConfig.NamedCapabilities) > 0 {
+		// Prefer to use NamedCapabilities
+		capabilities = make(types.CapabilityConfigs, 0)
+		for _, namedCapability := range runConfig.NamedCapabilities {
+			capabilities = append(capabilities, namedCapability)
+		}
+	}
+
 	// Terraform assumes that module source has a host of `registry.terraform.io` if not specified
 	// We are going to override that behavior to presume `api.nullstone.io` instead
 	for i, capability := range capabilities {

--- a/workspaces/capabilities.go
+++ b/workspaces/capabilities.go
@@ -76,17 +76,9 @@ func (g CapabilitiesGenerator) Generate(runConfig types.RunConfig) error {
 }
 
 func (g CapabilitiesGenerator) transformCapabilities(runConfig types.RunConfig) (types.CapabilityConfigs, error) {
-	capabilities := runConfig.Capabilities
-	if len(runConfig.NamedCapabilities) > 0 {
-		// Prefer to use NamedCapabilities
-		capabilities = make(types.CapabilityConfigs, 0)
-		for _, namedCapability := range runConfig.NamedCapabilities {
-			capabilities = append(capabilities, namedCapability)
-		}
-	}
-
 	// Terraform assumes that module source has a host of `registry.terraform.io` if not specified
 	// We are going to override that behavior to presume `api.nullstone.io` instead
+	capabilities := runConfig.Capabilities
 	for i, capability := range capabilities {
 		if ms, err := artifacts.ParseSource(capability.Source); err == nil {
 			if ms.Host == "" {

--- a/workspaces/run_config.go
+++ b/workspaces/run_config.go
@@ -20,15 +20,18 @@ func GetRunConfig(ctx context.Context, cfg api.Config, workspace Manifest) (type
 		return types.RunConfig{}, err
 	} else if runConfig == nil {
 		runConfig = &types.RunConfig{
-			WorkspaceUid:  uid,
-			Source:        "",
-			SourceVersion: "",
-			Variables:     types.Variables{},
-			Connections:   types.Connections{},
-			Capabilities:  types.CapabilityConfigs{},
-			Providers:     types.Providers{},
-			Targets:       types.RunTargets{},
-			Dependencies:  types.Dependencies{},
+			WorkspaceUid: uid,
+			Targets:      types.RunTargets{},
+			WorkspaceConfig: types.WorkspaceConfig{
+				Source:            "",
+				SourceVersion:     "",
+				Variables:         types.Variables{},
+				Connections:       types.Connections{},
+				Capabilities:      types.CapabilityConfigs{},
+				NamedCapabilities: types.NamedCapabilityConfigs{},
+				Providers:         types.Providers{},
+				Dependencies:      types.Dependencies{},
+			},
 		}
 	}
 

--- a/workspaces/run_config.go
+++ b/workspaces/run_config.go
@@ -23,14 +23,13 @@ func GetRunConfig(ctx context.Context, cfg api.Config, workspace Manifest) (type
 			WorkspaceUid: uid,
 			Targets:      types.RunTargets{},
 			WorkspaceConfig: types.WorkspaceConfig{
-				Source:            "",
-				SourceVersion:     "",
-				Variables:         types.Variables{},
-				Connections:       types.Connections{},
-				Capabilities:      types.CapabilityConfigs{},
-				NamedCapabilities: types.NamedCapabilityConfigs{},
-				Providers:         types.Providers{},
-				Dependencies:      types.Dependencies{},
+				Source:        "",
+				SourceVersion: "",
+				Variables:     types.Variables{},
+				Connections:   types.Connections{},
+				Capabilities:  types.CapabilityConfigs{},
+				Providers:     types.Providers{},
+				Dependencies:  types.Dependencies{},
 			},
 		}
 	}


### PR DESCRIPTION
### Changes
- `NamedCapabilities` was added to `WorkspaceConfig`
- `WorkspaceConfig.Capabilities` was marked for deprecation
- `WorkspaceConfig` is inlined in `RunConfig` to synchronize data structures.
- When generating capabilities terraform (`nullstone workspaces select`), we now prefer `NamedCapabilities` if it's not empty