### PR TITLE
Added support for environment event actions (`env-launched`, `env-destroyed`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.140 (Mar 18, 2025)
+* Added support for environment event actions (`env-launched`, `env-destroyed`) to `iac` commands.
+
 # 0.0.139 (Mar 12, 2025)
 * Fixed resolution errors on new blocks when performing `nullstone iac test`.
 * Updated API client.

--- a/go.mod
+++ b/go.mod
@@ -14,14 +14,14 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01
-	github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a
+	github.com/nullstone-io/iac v0.0.0-20250318133320-35b77ccaa008
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/sync v0.10.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250318133220-7c4a863ec1b2
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1

--- a/go.mod
+++ b/go.mod
@@ -14,14 +14,14 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01
-	github.com/nullstone-io/iac v0.0.0-20250312022212-9c6ac7bc4a0b
+	github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a
 	github.com/nullstone-io/module v0.2.9
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/sync v0.10.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250312021847-d2173a44bf29
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01 h1:XilC7eZlCxaPxmNS/daBUWQsLt8xShmCq8yulFCsTmA=
 github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01/go.mod h1:R19LBaBhllWF8+mtTG0ADwNOXqPy89FV9js7mUIT6DY=
-github.com/nullstone-io/iac v0.0.0-20250312022212-9c6ac7bc4a0b h1:0mWRWDKyV6SyQ/XWK4aFJFETUFosFDrZ2kBsjLZbSyU=
-github.com/nullstone-io/iac v0.0.0-20250312022212-9c6ac7bc4a0b/go.mod h1:WGekK10tX51pcobqm0cmEWHEpHvTdUusOjdJ2Kb1COU=
+github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a h1:qEZPQj96TV7v6oG1mwuTx+KIIYjmatZ5tkZlxfYXP5g=
+github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a/go.mod h1:5f4/f8pjh/8HUagodYQiTxB1XZwPguHSSVuWlKRfOZI=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -734,8 +734,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250312021847-d2173a44bf29 h1:r4nAchI3LCxeXBWqqAjz+TyT3K+oT08vHqTVdka1Jfo=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250312021847-d2173a44bf29/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa h1:Hh0+KH9N87i0fyTONbEG4POqveO9GkqIK+L6QtyCP+4=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01 h1:XilC7eZlCxaPxmNS/daBUWQsLt8xShmCq8yulFCsTmA=
 github.com/nullstone-io/deployment-sdk v0.0.0-20250220020218-a4c3b683ba01/go.mod h1:R19LBaBhllWF8+mtTG0ADwNOXqPy89FV9js7mUIT6DY=
-github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a h1:qEZPQj96TV7v6oG1mwuTx+KIIYjmatZ5tkZlxfYXP5g=
-github.com/nullstone-io/iac v0.0.0-20250317221255-c309b0577a8a/go.mod h1:5f4/f8pjh/8HUagodYQiTxB1XZwPguHSSVuWlKRfOZI=
+github.com/nullstone-io/iac v0.0.0-20250318133320-35b77ccaa008 h1:abBbr56TQw1c98WoXQHZlbEFzLuwdv0n+51W8cy5SCI=
+github.com/nullstone-io/iac v0.0.0-20250318133320-35b77ccaa008/go.mod h1:Tjv3YDXf6maWZq/1STXKd88qMDaD3AXlErqY+ZfZpeM=
 github.com/nullstone-io/module v0.2.9 h1:PcYhPEemBbc+RdP+Q/DF0+XlwJkkNb5R17Hfv8qaYyc=
 github.com/nullstone-io/module v0.2.9/go.mod h1:btQiO0giVWDvvaQ7CLnPmuPPakJc55lAr8OlE1LK6hg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -734,8 +734,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa h1:Hh0+KH9N87i0fyTONbEG4POqveO9GkqIK+L6QtyCP+4=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250317220544-b4ce83ff8dfa/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250318133220-7c4a863ec1b2 h1:DnIc57I8v4J3/Xd0DWSLIUfoRs9LA3mRCu/dnyYEk98=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250318133220-7c4a863ec1b2/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=


### PR DESCRIPTION
This adds the following env event actions: `env-launched`, `env-destroyed`.
In addition, this adds validation of event actions and statuses to iac files.

The `nullstone iac test` command will now report issues with event actions and statuses as well as adding support for `env-launched`, `env-destroyed`.

Relies on https://github.com/nullstone-io/iac/pull/21 and https://github.com/nullstone-io/go-api-client/pull/114