### PR TITLE
Fix CLI documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ scoop install nullstone
 
 For a complete set of Nullstone documentation, visit [docs.nullstone.io](https://docs.nullstone.io). Check out the links below for specific topics within the docs.
 
-- [CLI Docs](https://docs.nullstone.io/getting-started/cli-docs/overview.html) - 
+- [CLI Docs](https://docs.nullstone.io/getting-started/cli/docs.html) - 
 Learn more about the Nullstone CLI; including how to install and use it.
 
 ## Community & Support


### PR DESCRIPTION
## Context

Current link to CLI docs is throwing a 404 error.

<img width="885" height="518" alt="Screenshot 2025-11-24 at 16 18 16" src="https://github.com/user-attachments/assets/4350e1fc-82a0-4f3e-88f1-8e224f46f1a9" />
