### PR TITLE
Added CLI commands to search modules catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.174 (Apr 24, 2026)
+* Added `modules describe` CLI command to get info about a module.
+* Added `modules find` CLI command to find modules by taxonomy, name, and/or contributor filters.
+
 # 0.0.173 (Apr 02, 2026)
 * Added `--publish` flag to `apply` command to package and publish the module in the current directory before running the apply.
 * Fixed "Workspace out of changes" errors that periodically occur.

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -33,6 +33,8 @@ var Modules = &cli.Command{
 	Subcommands: []*cli.Command{
 		ModulesGenerate,
 		ModulesList,
+		ModulesFind,
+		ModulesDescribe,
 		ModulesRegister,
 		ModulesPublish,
 		ModulesPackage,
@@ -40,10 +42,12 @@ var Modules = &cli.Command{
 }
 
 var ModulesList = &cli.Command{
-	Name:        "list",
-	Description: "Shows a list of modules in the Nullstone registry for the current organization.",
-	Usage:       "List modules",
-	UsageText:   "nullstone modules list",
+	Name: "list",
+	Description: "Lists the modules owned by the current organization. " +
+		"Intended for module contributors managing their org's registry. " +
+		"To search the entire Nullstone registry (Nullstone-official, community, etc.), use `nullstone modules find`.",
+	Usage:     "List modules owned by the current organization",
+	UsageText: "nullstone modules list",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "detailed",

--- a/cmd/modules_describe.go
+++ b/cmd/modules_describe.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ryanuber/columnize"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+type moduleDescribeOutput struct {
+	Module  types.Module         `json:"module"`
+	Version *types.ModuleVersion `json:"version,omitempty"`
+}
+
+var ModulesDescribe = &cli.Command{
+	Name: "describe",
+	Description: "Fetches metadata for a module and one of its versions. " +
+		"The positional argument accepts `[<org>/]<name>[@<version>]`. " +
+		"If the organization is omitted, the current organization is used. " +
+		"If a version is specified via `@<version>`, the `--version` flag must not also be set. " +
+		"When no version is provided, the latest published version is described.",
+	Usage:     "Describe a module and one of its versions",
+	UsageText: "nullstone modules describe [<org>/]<name>[@<version>] [--version=<version>] [--format=json|pretty]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "version",
+			Aliases: []string{"v"},
+			Usage:   "Module version to describe. Defaults to the latest published version. Cannot be combined with `@<version>` in the positional argument.",
+		},
+		&cli.StringFlag{
+			Name:  "format",
+			Usage: "Output format. One of: json (default), pretty",
+			Value: "json",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := context.TODO()
+
+		if c.NArg() < 1 {
+			return fmt.Errorf("module reference is required: [<org>/]<name>[@<version>]")
+		}
+		if c.NArg() > 1 {
+			return fmt.Errorf("only one module reference is allowed")
+		}
+
+		ref := c.Args().First()
+		orgFromRef, name, versionFromRef, err := parseModuleRef(ref)
+		if err != nil {
+			return err
+		}
+
+		versionFromFlag := c.String("version")
+		if versionFromRef != "" && versionFromFlag != "" {
+			return fmt.Errorf("cannot specify both `@<version>` in the positional argument and `--version`")
+		}
+		version := versionFromRef
+		if version == "" {
+			version = versionFromFlag
+		}
+
+		format := strings.ToLower(c.String("format"))
+		if format != "json" && format != "pretty" {
+			return fmt.Errorf("invalid --format %q: must be json or pretty", format)
+		}
+
+		return ProfileAction(c, func(cfg api.Config) error {
+			orgName := orgFromRef
+			if orgName == "" {
+				orgName = cfg.OrgName
+			}
+			if orgName == "" {
+				return ErrMissingOrg
+			}
+
+			client := api.Client{Config: cfg}
+			module, err := client.Modules().Get(ctx, orgName, name)
+			if err != nil {
+				return fmt.Errorf("error retrieving module: %w", err)
+			}
+			if module == nil {
+				return fmt.Errorf("module %s/%s does not exist", orgName, name)
+			}
+
+			var moduleVersion *types.ModuleVersion
+			if version == "" || version == "latest" {
+				moduleVersion = module.LatestVersion
+				if moduleVersion == nil {
+					return fmt.Errorf("module %s/%s has no published versions", orgName, name)
+				}
+			} else {
+				moduleVersion, err = client.ModuleVersions().Get(ctx, orgName, name, version)
+				if err != nil {
+					return fmt.Errorf("error retrieving module version %s: %w", version, err)
+				}
+				if moduleVersion == nil {
+					return fmt.Errorf("version %s of module %s/%s does not exist", version, orgName, name)
+				}
+			}
+
+			out := moduleDescribeOutput{Module: *module, Version: moduleVersion}
+			if format == "pretty" {
+				writeModuleDescribePretty(os.Stdout, out)
+				return nil
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
+		})
+	},
+}
+
+// parseModuleRef parses a reference of the form `[<org>/]<name>[@<version>]`.
+func parseModuleRef(ref string) (org, name, version string, err error) {
+	if ref == "" {
+		return "", "", "", fmt.Errorf("module reference is empty")
+	}
+	// Split off the version, if present. Version strings don't contain '@',
+	// so a single '@' cleanly separates name from version.
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		version = ref[idx+1:]
+		ref = ref[:idx]
+		if version == "" {
+			return "", "", "", fmt.Errorf("missing version after '@'")
+		}
+	}
+	if slashIdx := strings.Index(ref, "/"); slashIdx >= 0 {
+		org = ref[:slashIdx]
+		name = ref[slashIdx+1:]
+	} else {
+		name = ref
+	}
+	if name == "" {
+		return "", "", "", fmt.Errorf("module name is required")
+	}
+	return org, name, version, nil
+}
+
+func writeModuleDescribePretty(w *os.File, out moduleDescribeOutput) {
+	m := out.Module
+	rows := []string{
+		fmt.Sprintf("Org|%s", m.OrgName),
+		fmt.Sprintf("Name|%s", m.Name),
+		fmt.Sprintf("Friendly Name|%s", m.FriendlyName),
+	}
+	if m.Description != "" {
+		rows = append(rows, fmt.Sprintf("Description|%s", m.Description))
+	}
+	category := string(m.Category)
+	if m.Subcategory != "" {
+		category = fmt.Sprintf("%s/%s", category, m.Subcategory)
+	}
+	rows = append(rows, fmt.Sprintf("Category|%s", category))
+	if len(m.ProviderTypes) > 0 {
+		rows = append(rows, fmt.Sprintf("Providers|%s", strings.Join(m.ProviderTypes, ", ")))
+	}
+	platform := m.Platform
+	if m.Subplatform != "" {
+		platform = fmt.Sprintf("%s/%s", platform, m.Subplatform)
+	}
+	if platform != "" {
+		rows = append(rows, fmt.Sprintf("Platform|%s", platform))
+	}
+	if m.Type != "" {
+		rows = append(rows, fmt.Sprintf("Type|%s", m.Type))
+	}
+	rows = append(rows,
+		fmt.Sprintf("Public|%t", m.IsPublic),
+		fmt.Sprintf("Status|%s", m.Status),
+	)
+	if m.SourceUrl != "" {
+		rows = append(rows, fmt.Sprintf("Source URL|%s", m.SourceUrl))
+	}
+
+	fmt.Fprintln(w, "Module")
+	fmt.Fprintln(w, columnize.Format(rows, columnize.DefaultConfig()))
+
+	if out.Version == nil {
+		return
+	}
+	v := out.Version
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Version")
+	vrows := []string{
+		fmt.Sprintf("Version|%s", v.Version),
+		fmt.Sprintf("Tool|%s", v.ToolName),
+		fmt.Sprintf("Created At|%s", v.CreatedAt),
+	}
+	if len(v.Manifest.Providers) > 0 {
+		vrows = append(vrows, fmt.Sprintf("Manifest Providers|%s", strings.Join(v.Manifest.Providers, ", ")))
+	}
+	vrows = append(vrows,
+		fmt.Sprintf("Variables|%d", len(v.Manifest.Variables)),
+		fmt.Sprintf("Outputs|%d", len(v.Manifest.Outputs)),
+		fmt.Sprintf("Connections|%d", len(v.Manifest.Connections)),
+		fmt.Sprintf("Env Variables|%d", len(v.Manifest.EnvVariables)),
+	)
+	fmt.Fprintln(w, columnize.Format(vrows, columnize.DefaultConfig()))
+}

--- a/cmd/modules_find.go
+++ b/cmd/modules_find.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ryanuber/columnize"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+var ModulesFind = &cli.Command{
+	Name: "find",
+	Description: "Search the entire Nullstone module registry across Nullstone-official, your org, and community modules. " +
+		"To list modules owned by your organization, use `nullstone modules list`. " +
+		"When `--contributor` is not specified, results include Nullstone-official and your organization's modules.",
+	Usage:     "Search the Nullstone module registry",
+	UsageText: "nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "category",
+			Usage: "Filter modules by category. Known values: app, capability, datastore, ingress, subdomain, domain, cluster, cluster-namespace, network, block",
+		},
+		&cli.StringFlag{
+			Name:  "subcategory",
+			Usage: "Filter modules by subcategory. Requires --category. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry",
+		},
+		&cli.StringFlag{
+			Name:  "provider",
+			Usage: "Filter modules by provider type. Known values: aws, gcp, azure",
+		},
+		&cli.StringFlag{
+			Name:  "platform",
+			Usage: "Filter modules by platform",
+		},
+		&cli.StringFlag{
+			Name:  "subplatform",
+			Usage: "Filter modules by subplatform. Requires --platform.",
+		},
+		&cli.StringFlag{
+			Name:  "name",
+			Usage: "Fuzzy match modules by name",
+		},
+		&cli.StringSliceFlag{
+			Name:  "contributor",
+			Usage: "Filter by contributor. Repeat the flag to include multiple. Allowed values: nullstone-official, my-org, community. Defaults to nullstone-official,my-org.",
+		},
+		&cli.StringFlag{
+			Name:  "format",
+			Usage: "Output format. One of: table (default), json",
+			Value: "table",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := context.TODO()
+
+		if c.IsSet("subcategory") && !c.IsSet("category") {
+			return fmt.Errorf("--subcategory requires --category")
+		}
+		if c.IsSet("subplatform") && !c.IsSet("platform") {
+			return fmt.Errorf("--subplatform requires --platform")
+		}
+
+		format := strings.ToLower(c.String("format"))
+		if format != "table" && format != "json" {
+			return fmt.Errorf("invalid --format %q: must be table or json", format)
+		}
+
+		contributors, err := parseContributors(c.StringSlice("contributor"))
+		if err != nil {
+			return err
+		}
+
+		input := api.FindModulesInput{Contributor: contributors}
+		if c.IsSet("category") {
+			v := c.String("category")
+			input.Category = &v
+		}
+		if c.IsSet("subcategory") {
+			v := c.String("subcategory")
+			input.Subcategory = &v
+		}
+		if c.IsSet("provider") {
+			v := c.String("provider")
+			input.Provider = &v
+		}
+		if c.IsSet("platform") {
+			v := c.String("platform")
+			input.Platform = &v
+		}
+		if c.IsSet("subplatform") {
+			v := c.String("subplatform")
+			input.Subplatform = &v
+		}
+		if c.IsSet("name") {
+			v := c.String("name")
+			input.Name = &v
+		}
+
+		return ProfileAction(c, func(cfg api.Config) error {
+			client := api.Client{Config: cfg}
+			found, err := client.Modules().Find(ctx, cfg.OrgName, input)
+			if err != nil {
+				return fmt.Errorf("error searching modules: %w", err)
+			}
+
+			if format == "json" {
+				if found == nil {
+					found = []types.Module{}
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(found)
+			}
+			writeModulesFindTable(found)
+			return nil
+		})
+	},
+}
+
+func parseContributors(raw []string) ([]types.Contributor, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	valid := map[string]types.Contributor{}
+	for _, c := range types.AllContributors {
+		valid[string(c)] = c
+	}
+	out := make([]types.Contributor, 0, len(raw))
+	for _, r := range raw {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		v, ok := valid[r]
+		if !ok {
+			allowed := make([]string, 0, len(types.AllContributors))
+			for _, c := range types.AllContributors {
+				allowed = append(allowed, string(c))
+			}
+			return nil, fmt.Errorf("invalid --contributor %q: must be one of %s", r, strings.Join(allowed, ", "))
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func writeModulesFindTable(modules []types.Module) {
+	rows := make([]string, 0, len(modules)+1)
+	rows = append(rows, "org|name|category|provider|platform|latest-version")
+	for _, m := range modules {
+		category := string(m.Category)
+		if m.Subcategory != "" {
+			category = fmt.Sprintf("%s/%s", category, m.Subcategory)
+		}
+		platform := m.Platform
+		if m.Subplatform != "" {
+			platform = fmt.Sprintf("%s/%s", platform, m.Subplatform)
+		}
+		latest := "<no-versions>"
+		if m.LatestVersion != nil {
+			latest = m.LatestVersion.Version
+		}
+		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+			m.OrgName,
+			m.Name,
+			category,
+			strings.Join(m.ProviderTypes, ","),
+			platform,
+			latest,
+		))
+	}
+	fmt.Println(columnize.Format(rows, columnize.DefaultConfig()))
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260424183812-f221aacd1df3
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9 h1:ON/Bty+Xt3JLF6b4NsONh3RGILpumGQu4rUflyGH8Ww=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260424183812-f221aacd1df3 h1:2cY2ggs8Ca6cKWYyAeTuuPRdB/L/lqJkUZLZSfOCP0Q=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260424183812-f221aacd1df3/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/mcp/executor.go
+++ b/mcp/executor.go
@@ -123,6 +123,8 @@ func toolNameToSubcommands(toolName string) []string {
 		"modules_register":  {"modules", "register"},
 		"modules_publish":   {"modules", "publish"},
 		"modules_package":   {"modules", "package"},
+		"modules_describe":  {"modules", "describe"},
+		"modules_find":      {"modules", "find"},
 	}
 
 	if cmds, ok := mapping[toolName]; ok {
@@ -139,6 +141,8 @@ func toolPositionalArgs(toolName string) []string {
 	switch toolName {
 	case "set_org":
 		return []string{"org_name"}
+	case "modules_describe":
+		return []string{"module"}
 	default:
 		return nil
 	}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -16,6 +16,8 @@ func AllTools() []mcp.Tool {
 		statusTool(),
 		profileTool(),
 		logsTool(),
+		modulesDescribeTool(),
+		modulesFindTool(),
 
 		// Create/modify
 		stacksNewTool(),
@@ -586,6 +588,59 @@ func iacGenerateTool() mcp.Tool {
 }
 
 // --- Module tools ---
+
+func modulesDescribeTool() mcp.Tool {
+	return mcp.NewTool("modules_describe",
+		withGlobalParams(
+			mcp.WithDescription("Fetch metadata for a module and one of its versions. The `module` argument accepts `[<org>/]<name>[@<version>]`. If org is omitted, the current organization is used. If version is omitted, the latest published version is described."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("module",
+				mcp.Required(),
+				mcp.Description("Module reference as `[<org>/]<name>[@<version>]`, e.g. `nullstone/aws-network` or `nullstone/aws-network@1.2.3`."),
+			),
+			mcp.WithString("version",
+				mcp.Description("Module version. Cannot be combined with `@<version>` in the `module` argument. Defaults to the latest published version."),
+			),
+			mcp.WithString("format",
+				mcp.Description("Output format. One of: json (default), pretty."),
+			),
+		)...,
+	)
+}
+
+func modulesFindTool() mcp.Tool {
+	return mcp.NewTool("modules_find",
+		withGlobalParams(
+			mcp.WithDescription("Search the entire Nullstone module registry. All filters are optional. Use this to discover modules across Nullstone-official, your org, and community contributors."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("category",
+				mcp.Description("Filter by category. Known values: app, capability, datastore, ingress, subdomain, domain, cluster, cluster-namespace, network, block."),
+			),
+			mcp.WithString("subcategory",
+				mcp.Description("Filter by subcategory. Requires category."),
+			),
+			mcp.WithString("provider",
+				mcp.Description("Filter by provider type. Known values: aws, gcp, azure."),
+			),
+			mcp.WithString("platform",
+				mcp.Description("Filter by platform."),
+			),
+			mcp.WithString("subplatform",
+				mcp.Description("Filter by subplatform. Requires platform."),
+			),
+			mcp.WithString("name",
+				mcp.Description("Fuzzy match modules by name."),
+			),
+			mcp.WithArray("contributor",
+				mcp.Description("Filter by contributor. Provide one or more of: nullstone-official, my-org, community, all. Defaults to [nullstone-official, my-org]."),
+				mcp.WithStringItems(),
+			),
+			mcp.WithString("format",
+				mcp.Description("Output format. One of: table (default), json."),
+			),
+		)...,
+	)
+}
 
 func modulesRegisterTool() mcp.Tool {
 	return mcp.NewTool("modules_register",


### PR DESCRIPTION
Added 2 CLI commands to aid agent skill that helps AI interact with nullstone IaC files.
These commands help identify which top-level item (e.g. apps, datastores, etc.) to add a Nullstone block.
It also helps identify which variables and connections are available for the module/module version selected.

* Added `modules describe` CLI command to get info about a module.
* Added `modules find` CLI command to find modules by taxonomy, name, and/or contributor filters.