### PR TITLE
Fix: remove premature cancel() in monitor Job to allow k8s log flushing

### DIFF
--- a/k8s/job_runner.go
+++ b/k8s/job_runner.go
@@ -123,7 +123,6 @@ func (r JobRunner) monitorJob(ctx context.Context, client *kubernetes.Clientset,
 		return nil
 	})
 	eg.Go(func() error {
-		defer cancel()
 		for {
 			// check status of job
 			containerStatus, err := r.getJobContainerStatus(ctx, client, jobName)


### PR DESCRIPTION
Fixes #604 log flushing not finishing

Problem:
When running nullstone run against a k8s job, the CLI was 
completing before logs fully flushed to the user.

In k8s/job_runner.go line 126, the defer cancel() in the status 
goroutine was firing immediately when the job terminated, cancelling 
the context before the log streamer had a chance to flush.

How It Should Flow:
1. k8s/job_runner.go line 134-139 - job status goroutine detects 
   containerStatus.State.Terminated and returns

2. deployment-sdk/k8s/log_streamer.go line 80-85 - pod watcher sees 
   PodSucceeded/PodFailed and calls streamers.Remove(podName)

3. deployment-sdk/k8s/logs/pod_streamer.go line 48-50 - Stop() is 
   called on each ContainerStreamer, closing stopCh

4. deployment-sdk/k8s/logs/container_streamer.go line 71-75 - 
   stopCh triggers flush() which reads remaining logs for up to 
   StopFlushTimeout (1000ms) defined on line 100-115

What Was Happening:
defer cancel() on line 126 of k8s/job_runner.go was 
short-circuiting the entire flow above by cancelling the context 
immediately, jumping to CancelFlushTimeout (250ms) in 
deployment-sdk/k8s/log_streamer.go line 38-42 and bypassing 
flush() entirely.

Fix:
Removed `defer cancel()` from line 126 in `k8s/job_runner.go`. 
The pod watcher now shuts down naturally, allowing the full flush 
chain to complete.