### PR TITLE
Added `--if=any-changes` to `nullstone apply` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.176 (May 07, 2026)
 * Added `--app-version` to `nullstone apply` command to update the app's deployed version during apply.
+* Added `--if` to `nullstone apply` command to skip creating a run if there are no outstanding changes to the workspace configuration.
 
 # 0.0.175 (May 04, 2026)
 * Added filter support for `nullstone logs` for GKE/EKS apps. (`--pod-template-hash`, `--pod`, `--job`).

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -51,11 +51,21 @@ var Apply = func() *cli.Command {
 				Name:  "app-version",
 				Usage: "Force a specific app version to be used during the apply. Only valid for application blocks.",
 			},
+			&cli.StringFlag{
+				Name:  "if",
+				Usage: "Only create the run when the condition is met. Supported: `any-changes` (skip if there are no unapplied workspace changes).",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			varFlags := c.StringSlice("var")
 			moduleVersion := c.String("module-version")
 			publish := c.Bool("publish")
+			condition := c.String("if")
+			switch condition {
+			case "", "any-changes":
+			default:
+				return cli.Exit(fmt.Sprintf("unsupported value for --if: %q (supported: any-changes)", condition), 1)
+			}
 			var autoApprove *bool
 			if c.IsSet("auto-approve") {
 				val := c.Bool("auto-approve")
@@ -108,6 +118,7 @@ var Apply = func() *cli.Command {
 					IsDestroy:  false,
 					BlockType:  types.BlockType(block.Type),
 					StreamLogs: c.IsSet("wait"),
+					Condition:  condition,
 				}
 				if err := PerformRun(ctx, cfg, logger, input); err != nil {
 					// Map run errors to specific exit codes

--- a/cmd/perform_run.go
+++ b/cmd/perform_run.go
@@ -23,6 +23,9 @@ type PerformRunInput struct {
 	IsDestroy  bool
 	BlockType  types.BlockType
 	StreamLogs bool
+	// Condition is an optional server-side condition for creating the run.
+	// "" = always create. "any-changes" = skip when no unapplied workspace changes exist.
+	Condition string
 }
 
 func PerformRun(ctx context.Context, cfg api.Config, logger *log.Logger, input PerformRunInput) error {
@@ -31,11 +34,14 @@ func PerformRun(ctx context.Context, cfg api.Config, logger *log.Logger, input P
 	defer logger.SetPrefix("")
 
 	latestUpdateAt := time.Now().Add(time.Second)
-	result, err := api_runs.Create(ctx, cfg, input.Workspace, input.CommitSha, input.IsApproved, latestUpdateAt, input.IsDestroy, "", input.AppVersion)
+	result, err := api_runs.Create(ctx, cfg, input.Workspace, input.CommitSha, input.IsApproved, latestUpdateAt, input.IsDestroy, "", nil, input.Condition)
 	if err != nil {
 		return fmt.Errorf("error creating run: %w", err)
 	} else if result == nil {
 		return fmt.Errorf("unable to create run")
+	} else if result.Skipped {
+		logger.Println("no workspace changes — skipping apply")
+		return nil
 	}
 
 	var newRun types.Run

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508002026-4339fe6668f2
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508184209-701ba027b204
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508002026-4339fe6668f2 h1:w57F3ENVgnGD+j40VwRaF89aDHLclzUy4/W1S6kqQ14=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508002026-4339fe6668f2/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508184209-701ba027b204 h1:Q/xLgb37jfhng347NSJTvGzjETDgWXF4cElmP7ufq4A=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260508184209-701ba027b204/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This adds a new flag `--if=any-changes` to `nullstone apply` command.
If specified, a run is created *only if* there are outstanding workspace changes that need applied.