### PR TITLE
Feat/needs app infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.182 (May 20, 2026)
+* Added NeedsAppInfra to capability metadata so that generating app modules conditionally adds `app_infra` var to the module.
+
 # 0.0.181 (May 20, 2026)
 * Added `--env-var` flag to `nullstone launch` and `nullstone deploy` commands to set environment variables for new deployments.
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.51.0
 	golang.org/x/sync v0.20.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520151138-52af136b91ac
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520151138-52af136b91ac h1:cvnVYAE+iTC1n7iHnv640FsSnok8iNLOtX9/Z72oWvc=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520151138-52af136b91ac/go.mod h1:THcJidhDCJRYgp6J/Xo8KV2LkK+peC5qcFVWRN1TCMw=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005 h1:s+bMuHog7gYUKxg4co7u/o9udGCouORUK82ExKPmmRE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005/go.mod h1:THcJidhDCJRYgp6J/Xo8KV2LkK+peC5qcFVWRN1TCMw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/workspaces/capabilities.go
+++ b/workspaces/capabilities.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/nullstone-io/module/config"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/go-api-client.v0/artifacts"
 	"gopkg.in/nullstone-io/go-api-client.v0/find"
@@ -133,16 +134,30 @@ func (g CapabilitiesGenerator) resolveCapabilityMeta(cur types.CapabilityConfig)
 	if err != nil {
 		return nil, err
 	}
+
 	meta.OutputNames = slices.Collect(maps.Keys(mv.Manifest.Outputs))
-	// env + secrets don't show up in the manifest outputs; we should always include them
-	meta.OutputNames = append(meta.OutputNames, "env", "secrets")
+	// env + secrets don't show up in the manifest outputs; should we include them?
+	if envVarsMapHas(mv.Manifest.EnvVariables, false) {
+		meta.OutputNames = append(meta.OutputNames, "env")
+	}
+	if envVarsMapHas(mv.Manifest.EnvVariables, true) {
+		meta.OutputNames = append(meta.OutputNames, "secrets")
+	}
 	if meta.OutputNames == nil {
 		meta.OutputNames = make([]string, 0)
 	}
-
 	if mv.Manifest.Variables != nil {
 		_, meta.NeedsAppInfra = mv.Manifest.Variables["app_infra"]
 	}
 
 	return meta, nil
+}
+
+func envVarsMapHas(envVars map[string]config.EnvVariable, checkSensitive bool) bool {
+	for _, v := range envVars {
+		if v.Sensitive == checkSensitive {
+			return true
+		}
+	}
+	return false
 }

--- a/workspaces/capabilities.go
+++ b/workspaces/capabilities.go
@@ -146,6 +146,7 @@ func (g CapabilitiesGenerator) resolveCapabilityMeta(cur types.CapabilityConfig)
 	if meta.OutputNames == nil {
 		meta.OutputNames = make([]string, 0)
 	}
+	
 	if mv.Manifest.Variables != nil {
 		_, meta.NeedsAppInfra = mv.Manifest.Variables["app_infra"]
 	}

--- a/workspaces/capabilities.go
+++ b/workspaces/capabilities.go
@@ -140,5 +140,9 @@ func (g CapabilitiesGenerator) resolveCapabilityMeta(cur types.CapabilityConfig)
 		meta.OutputNames = make([]string, 0)
 	}
 
+	if mv.Manifest.Variables != nil {
+		_, meta.NeedsAppInfra = mv.Manifest.Variables["app_infra"]
+	}
+
 	return meta, nil
 }


### PR DESCRIPTION
This amends capability generation to make two improvements:
- Added `NeedsAppInfra` which is an optional capability module variable. This allows an app module creator to conditionally add that variable. This variable is used to communicate the primary app infrastructure to a capability which creates a cyclical reference in many scenarios.
- Previously, we always included `env` and `secrets` in capability output names. This was inaccurate; this was changed to improve the accuracy so an app module creator can optimize.
