### PR TITLE
Feat/71/releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.184 (May 28, 2026)
+* Added `nullstone release` command that runs infra-update and/or deploy through a single workflow, letting Nullstone pick the optimal path.
+* Removed `--app-version` from `nullstone apply` (it was never wired through); use `nullstone release` to make infra changes and a new app version live together.
+
 # 0.0.183 (May 27, 2026)
 * Added `--wait` flag to `nullstone iac sync` to wait for iac sync to complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# 0.0.184 (May 28, 2026)
+# 0.0.183 (May 29, 2026)
+* Added `--wait` flag to `nullstone iac sync` to wait for iac sync to complete.
 * Added `nullstone release` command that runs infra-update and/or deploy through a single workflow, letting Nullstone pick the optimal path.
 * Removed `--app-version` from `nullstone apply` (it was never wired through); use `nullstone release` to make infra changes and a new app version live together.
-
-# 0.0.183 (May 27, 2026)
-* Added `--wait` flag to `nullstone iac sync` to wait for iac sync to complete.
 
 # 0.0.182 (May 20, 2026)
 * Added NeedsAppInfra to capability metadata so that generating app modules conditionally adds `app_infra` var to the module.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test:
 
 docs:
 	go run ./docs/main.go
+	cp ./docs/CLI.md ../docs/src/getting-started/cli/docs.md
 
 upgrade-aws:
 	go get -u github.com/aws/aws-sdk-go-v2/...

--- a/app/build.go
+++ b/app/build.go
@@ -45,6 +45,7 @@ func Build() *cli.App {
 		cmd.Push(appProviders),
 		cmd.Deploy(appProviders),
 		cmd.Launch(appProviders),
+		cmd.Release(appProviders),
 		cmd.Logs(appProviders),
 		cmd.Status(adminProviders),
 		cmd.Exec(appProviders, adminProviders),

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -48,10 +48,6 @@ var Apply = func() *cli.Command {
 				Usage: "Package and publish the module in the current directory before running the apply. Uses `next-build` for the version by default, or the value of `--module-version` if specified.",
 			},
 			&cli.StringFlag{
-				Name:  "app-version",
-				Usage: "Force a specific app version to be used during the apply. Only valid for application blocks.",
-			},
-			&cli.StringFlag{
 				Name:  "if",
 				Usage: "Only create the run when the condition is met. Supported: `any-changes` (skip if there are no unapplied workspace changes).",
 			},
@@ -101,19 +97,9 @@ var Apply = func() *cli.Command {
 					return err
 				}
 
-				var appVersion *string
-				if c.IsSet("app-version") {
-					if block.Type != string(types.BlockTypeApplication) {
-						return fmt.Errorf("--app-version is only valid for application blocks; %q is a %s block", block.Name, block.Type)
-					}
-					v := c.String("app-version")
-					appVersion = &v
-				}
-
 				input := PerformRunInput{
 					Workspace:  workspace,
 					CommitSha:  "",
-					AppVersion: appVersion,
 					IsApproved: autoApprove,
 					IsDestroy:  false,
 					BlockType:  types.BlockType(block.Type),

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -135,6 +135,9 @@ func streamDeployIntentLogs(ctx context.Context, osWriters logging.OsWriters, cf
 	} else if iw.Status == types.IntentWorkflowStatusCompleted {
 		colorstring.Fprintln(stderr, "[green]Deployment completed.[reset]")
 		return nil
+	} else if iw.Status == types.IntentWorkflowStatusNoOp {
+		colorstring.Fprintln(stderr, "[green]Nothing to release.[reset]")
+		return nil
 	}
 
 	colorstring.Fprintln(stderr, "[green]Deployment started.[reset]")

--- a/cmd/perform_run.go
+++ b/cmd/perform_run.go
@@ -18,7 +18,6 @@ import (
 type PerformRunInput struct {
 	Workspace  types.Workspace
 	CommitSha  string
-	AppVersion *string
 	IsApproved *bool
 	IsDestroy  bool
 	BlockType  types.BlockType

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -58,15 +58,15 @@ var Release = func(providers app.Providers) *cli.Command {
 				}
 
 				payload := api.ReleaseCreatePayload{
-					IsApproved: autoApprove,
+					AutomationTool: detectAutomationTool(),
+					IsApproved:     autoApprove,
 					Apps: []api.ReleaseApp{
 						{
-							AppId:          appDetails.App.Id,
-							FromSource:     false,
-							Version:        info.EffectiveVersion,
-							CommitSha:      info.CommitInfo.CommitSha,
-							AutomationTool: detectAutomationTool(),
-							EnvVars:        envVars,
+							AppId:      appDetails.App.Id,
+							FromSource: false,
+							Version:    info.EffectiveVersion,
+							CommitSha:  info.CommitInfo.CommitSha,
+							EnvVars:    envVars,
 						},
 					},
 				}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+)
+
+var Release = func(providers app.Providers) *cli.Command {
+	waitFlag := &cli.BoolFlag{
+		Name:    "wait",
+		Aliases: []string{"w"},
+		Usage:   "Wait for the release to complete and stream the logs to the console.",
+	}
+	autoApproveFlag := &cli.BoolFlag{
+		Name:  "auto-approve",
+		Usage: "Skip any approvals on the infra-update. This requires proper permissions in the stack.",
+	}
+
+	return &cli.Command{
+		Name: "release",
+		Description: "Make your infra and app code live through a single workflow. Nullstone runs an infra-update " +
+			"when there are outstanding workspace changes and a deploy for the resolved app version, picking the " +
+			"optimal, most reliable path.",
+		Usage:     "Release infra changes and/or a new app version",
+		UsageText: "nullstone release [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]",
+		Flags: []cli.Flag{
+			StackFlag,
+			AppFlag,
+			OldEnvFlag,
+			AppVersionFlag,
+			EnvVarFlag,
+			autoApproveFlag,
+			waitFlag,
+		},
+		Action: func(c *cli.Context) error {
+			return AppWorkspaceAction(c, func(ctx context.Context, cfg api.Config, appDetails app.Details) error {
+				osWriters := CliOsWriters{Context: c}
+				wait := c.IsSet(waitFlag.Name)
+
+				info, err := calcDeployInfo(ctx, c)
+				if err != nil {
+					return err
+				}
+
+				envVars, err := ParseEnvVars(c)
+				if err != nil {
+					return err
+				}
+
+				var autoApprove *bool
+				if c.IsSet(autoApproveFlag.Name) {
+					val := c.Bool(autoApproveFlag.Name)
+					autoApprove = &val
+				}
+
+				payload := api.ReleaseCreatePayload{
+					FromSource:     false,
+					Version:        info.EffectiveVersion,
+					CommitSha:      info.CommitInfo.CommitSha,
+					AutomationTool: detectAutomationTool(),
+					EnvVars:        envVars,
+					IsApproved:     autoApprove,
+				}
+
+				fmt.Fprintln(osWriters.Stderr(), "Creating release...")
+				client := api.Client{Config: cfg}
+				iw, err := client.Releases().Create(ctx, appDetails.App.StackId, appDetails.App.Id, appDetails.Env.Id, payload)
+				if err != nil {
+					return fmt.Errorf("error creating release: %w", err)
+				} else if iw == nil {
+					return fmt.Errorf("unable to create release")
+				}
+				fmt.Fprintln(osWriters.Stderr())
+
+				return streamDeployIntentLogs(ctx, osWriters, cfg, appDetails, *iw, wait)
+			})
+		},
+	}
+}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -58,17 +58,22 @@ var Release = func(providers app.Providers) *cli.Command {
 				}
 
 				payload := api.ReleaseCreatePayload{
-					FromSource:     false,
-					Version:        info.EffectiveVersion,
-					CommitSha:      info.CommitInfo.CommitSha,
-					AutomationTool: detectAutomationTool(),
-					EnvVars:        envVars,
-					IsApproved:     autoApprove,
+					IsApproved: autoApprove,
+					Apps: []api.ReleaseApp{
+						{
+							AppId:          appDetails.App.Id,
+							FromSource:     false,
+							Version:        info.EffectiveVersion,
+							CommitSha:      info.CommitInfo.CommitSha,
+							AutomationTool: detectAutomationTool(),
+							EnvVars:        envVars,
+						},
+					},
 				}
 
 				fmt.Fprintln(osWriters.Stderr(), "Creating release...")
 				client := api.Client{Config: cfg}
-				iw, err := client.Releases().Create(ctx, appDetails.App.StackId, appDetails.App.Id, appDetails.Env.Id, payload)
+				iw, err := client.Releases().Create(ctx, appDetails.App.StackId, appDetails.Env.Id, payload)
 				if err != nil {
 					return fmt.Errorf("error creating release: %w", err)
 				} else if iw == nil {

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/nullstone.v0/app_urls"
 )
 
 var Release = func(providers app.Providers) *cli.Command {
@@ -81,6 +82,12 @@ var Release = func(providers app.Providers) *cli.Command {
 				}
 				fmt.Fprintln(osWriters.Stderr())
 
+				// Without --wait, print the workflow URL and return; with --wait, stream the logs.
+				if !wait {
+					fmt.Fprintln(osWriters.Stderr(), "Started release, view status here:")
+					fmt.Fprintln(osWriters.Stdout(), app_urls.GetIntentWorkflow(cfg, *iw))
+					return nil
+				}
 				return streamDeployIntentLogs(ctx, osWriters, cfg, appDetails, *iw, wait)
 			})
 		},

--- a/cmd/wait_for.go
+++ b/cmd/wait_for.go
@@ -35,6 +35,8 @@ func waitForRunningIntentWorkflow(ctx context.Context, cfg api.Config, iw types.
 			return cur, nil
 		case types.IntentWorkflowStatusCompleted:
 			return cur, nil
+		case types.IntentWorkflowStatusNoOp:
+			return cur, nil
 		case types.IntentWorkflowStatusFailed:
 			return cur, fmt.Errorf("Deployment failed: %s", cur.StatusMessage)
 		case types.IntentWorkflowStatusCancelled:
@@ -61,6 +63,8 @@ func waitForCompletedIntentWorkflow(ctx context.Context, cfg api.Config, iw type
 	for {
 		switch cur.Status {
 		case types.IntentWorkflowStatusCompleted:
+			return cur, nil
+		case types.IntentWorkflowStatusNoOp:
 			return cur, nil
 		case types.IntentWorkflowStatusFailed:
 			return cur, fmt.Errorf("Deployment failed: %s", cur.StatusMessage)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -83,7 +83,7 @@ $ nullstone blocks new --name=<name> --stack=<stack> --module=<module> [--connec
 | `--name` | Provide a name for this new block | required |
 | `--module` | Specify the unique name of the module to use for this block. Example: nullstone/aws-network | required |
 | `--connection` | Specify any connections that this block will have to other blocks. Use the connection name as the key, and the connected block name as the value. Example: --connection network=network0 |  |
-| `--dns-template` | Specify a template for the dns name portion of the subdomain.This is a template that allows you to add "{{ NULLSTONE_ENV }}" and "{{ NULLSTONE_ORG }}" in template.In production, the "{{ NULLSTONE_ENV }}" will be omitted to create a vanity subdomain.Nullstone will interpolate the template to create a subdomain: "`dns-name`.`domain-name`".If you want to create a ".nullstone.app" subdomain using an "autogen" or "nullstone-subdomain" module, set this to "{{ random() }}".For a subdomain on your custom domain, set this to something like "api.{{ NULLSTONE_ENV }}".- "dev" env =` api.dev.example.com- "prod" env =` api.example.com |  |
+| `--dns-template` | Specify a template for the dns name portion of the subdomain.This is a template that allows you to add "<code v-pre>{{ NULLSTONE_ENV }}</code>" and "<code v-pre>{{ NULLSTONE_ORG }}</code>" in template.In production, the "<code v-pre>{{ NULLSTONE_ENV }}</code>" will be omitted to create a vanity subdomain.Nullstone will interpolate the template to create a subdomain: "`dns-name`.`domain-name`".If you want to create a ".nullstone.app" subdomain using an "autogen" or "nullstone-subdomain" module, set this to "<code v-pre>{{ random() }}</code>".For a subdomain on your custom domain, set this to something like "api.<code v-pre>{{ NULLSTONE_ENV }}</code>".- "dev" env =` api.dev.example.com- "prod" env =` api.example.com |  |
 
 
 ## configure
@@ -116,7 +116,7 @@ $ nullstone deploy [--stack=<stack-name>] --app=<app-name> --env=<env-name> [opt
 | `--app` | Name of the app to use for this operation |  |
 | `--env` | Name of the environment to use for this operation |  |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
-| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using <code v-pre>{{ VAR }}</code>, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
 | `--wait, -w` | Wait for the deploy to complete and stream the logs to the console. |  |
 
 
@@ -288,7 +288,7 @@ $ nullstone launch [--stack=<stack-name>] --app=<app-name> --env=<env-name> [opt
 | `--env` | Name of the environment to use for this operation |  |
 | `--source` | The source artifact to push that contains your application's build.		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.		For a serverless zip application, specify the .zip archive to push.		For a static site, specify the directory to push. | required |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
-| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using <code v-pre>{{ VAR }}</code>, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
 
 
 ## logs
@@ -512,7 +512,7 @@ $ nullstone release [--stack=<stack-name>] --app=<app-name> --env=<env-name> [op
 | `--app` | Name of the app to use for this operation |  |
 | `--env` | Name of the environment to use for this operation |  |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
-| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using <code v-pre>{{ VAR }}</code>, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
 | `--auto-approve` | Skip any approvals on the infra-update. This requires proper permissions in the stack. |  |
 | `--wait, -w` | Wait for the release to complete and stream the logs to the console. |  |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,6 +28,7 @@ $ nullstone apply [--stack=<stack-name>] --block=<block-name> --env=<env-name> [
 | `--var` | Set variables values for the apply. This can be used to override variables defined in the module. |  |
 | `--module-version` | The version of the module to apply. When used with `--publish`, this specifies the version to publish (supports semver, `next-patch`, and `next-build`). |  |
 | `--publish` | Package and publish the module in the current directory before running the apply. Uses `next-build` for the version by default, or the value of `--module-version` if specified. |  |
+| `--if` | Only create the run when the condition is met. Supported: `any-changes` (skip if there are no unapplied workspace changes). |  |
 
 
 ## apps list
@@ -115,6 +116,7 @@ $ nullstone deploy [--stack=<stack-name>] --app=<app-name> --env=<env-name> [opt
 | `--app` | Name of the app to use for this operation |  |
 | `--env` | Name of the environment to use for this operation |  |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
 | `--wait, -w` | Wait for the deploy to complete and stream the logs to the console. |  |
 
 
@@ -252,6 +254,24 @@ $ nullstone iac --stack=<stack> --env=<env> --app=<app>
 | `--block` | Name of the block to use for this operation |  |
 
 
+## iac sync
+Sync IaC configuration to a Nullstone environment and optionally trigger infra updates.
+
+#### Usage
+```shell
+$ nullstone iac sync --stack=<stack> --env=<env> [--auto-plan] [--auto-apply] [--from-git] [--wait[=<dur>]]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--env` | Name of the environment to use for this operation | required |
+| `--auto-plan` | Queue an infra-update Run on each workspace where IaC changes are detected. The Run is left pending approval. |  |
+| `--auto-apply` | Auto-approve any infra-update Run created by the sync. Implies --auto-plan. |  |
+| `--from-git` | Force the server to fetch IaC files from the connected GitHub repo at the resolved commit SHA. By default the local files (already discovered by this command) are submitted in the request payload. |  |
+
+
 ## launch
 This command will first upload (push) an artifact containing the source for your application. Then it will deploy it to the given environment and tail the logs for the deployment.This command is the same as running `nullstone push` followed by `nullstone deploy -w`.
 
@@ -268,6 +288,7 @@ $ nullstone launch [--stack=<stack-name>] --app=<app-name> --env=<env-name> [opt
 | `--env` | Name of the environment to use for this operation |  |
 | `--source` | The source artifact to push that contains your application's build.		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.		For a serverless zip application, specify the .zip archive to push.		For a static site, specify the directory to push. | required |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
 
 
 ## logs
@@ -288,6 +309,11 @@ $ nullstone logs [--stack=<stack-name>] --app=<app-name> --env=<env-name> [optio
 | `--end-time, -e` |        Emit log events that occur before the specified end-time.        This is a golang duration relative to the time the command is issued.       Examples: '5s' (5 seconds ago), '1m' (1 minute ago), '24h' (24 hours ago)       |  |
 | `--interval` | Set --interval to a golang duration to control how often to pull new log events.       This will do nothing unless --tail is set. The default is '1s' (1 second).       |  |
 | `--tail, -t` | Set tail to watch log events and emit as they are reported.       Use --interval to control how often to query log events.       This is off by default. Unless this option is provided, this command will exit as soon as current log events are emitted. |  |
+| `--pod` | Restrict logs to a single pod by name (Kubernetes only). |  |
+| `--job` | Restrict logs to a single Kubernetes job by name (adds `job-name=`value`` to the selector) or a single ECS task by ID. |  |
+| `--pod-template-hash` | Restrict logs to a single ReplicaSet revision (adds `pod-template-hash=`value`` to the selector). |  |
+| `--task` | Restrict logs to a single ECS task by ID. |  |
+| `--deployment` | Restrict logs to a single ECS deployment by ID; logs from all tasks under the deployment are included. |  |
 
 
 ## mcp-server
@@ -314,7 +340,7 @@ $ nullstone modules generate [--register] [--manifest-only]
 
 
 ## modules list
-Shows a list of modules in the Nullstone registry for the current organization.
+Lists the modules owned by the current organization. Intended for module contributors managing their org's registry. To search the entire Nullstone registry (Nullstone-official, community, etc.), use `nullstone modules find`.
 
 #### Usage
 ```shell
@@ -333,6 +359,42 @@ $ nullstone modules list
 | `--subplatform` | Filter modules by subplatform |  |
 
 
+## modules find
+Search the entire Nullstone module registry across Nullstone-official, your org, and community modules. To list modules owned by your organization, use `nullstone modules list`. When `--contributor` is not specified, results include Nullstone-official and your organization's modules.
+
+#### Usage
+```shell
+$ nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--category` | Filter modules by category. Known values: app, capability, datastore, ingress, subdomain, domain, cluster, cluster-namespace, network, block |  |
+| `--subcategory` | Filter modules by subcategory. Requires --category. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry |  |
+| `--provider` | Filter modules by provider type. Known values: aws, gcp, azure |  |
+| `--platform` | Filter modules by platform |  |
+| `--subplatform` | Filter modules by subplatform. Requires --platform. |  |
+| `--name` | Fuzzy match modules by name |  |
+| `--contributor` | Filter by contributor. Repeat the flag to include multiple. Allowed values: nullstone-official, my-org, community. Defaults to nullstone-official,my-org. |  |
+| `--format` | Output format. One of: table (default), json |  |
+
+
+## modules describe
+Fetches metadata for a module and one of its versions. The positional argument accepts `[<org>/]<name>[@<version>]`. If the organization is omitted, the current organization is used. If a version is specified via `@<version>`, the `--version` flag must not also be set. When no version is provided, the latest published version is described.
+
+#### Usage
+```shell
+$ nullstone modules describe [<org>/]<name>[@<version>] [--version=<version>] [--format=json|pretty]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--version, -v` | Module version to describe. Defaults to the latest published version. Cannot be combined with `@`version`` in the positional argument. |  |
+| `--format` | Output format. One of: json (default), pretty |  |
+
+
 ## modules register
 Registers a module in the Nullstone registry. The information in .nullstone/module.yml will be used as the details for the new module.
 
@@ -346,13 +408,14 @@ Publishes a new version for a module in the Nullstone registry. Provide a specif
 
 #### Usage
 ```shell
-$ nullstone modules publish --version=<version>
+$ nullstone modules publish --version=<version> [--if=checksum-changed]
 ```
 
 #### Options
 | Option | Description | |
 | --- | --- | --- |
 | `--version, -v` | Specify a semver version for the module.'next-patch': Uses a version that bumps the patch component of the latest module version.'next-build': Uses the latest version and appends +`build` using the short Git commit SHA. (Fails if not in a Git repository) | required |
+| `--if` | Only publish when the condition is met. Supported: `checksum-changed` (skip when the packaged tarball matches the latest published version). |  |
 | `--include` | Specify additional file patterns to package. By default, this command includes *.tf, *.tf.tmpl, and 'README.md'. Use this flag to package additional modules and files needed for applies. This supports file globbing detailed at https://pkg.go.dev/path/filepath#Glob |  |
 
 
@@ -432,6 +495,26 @@ $ nullstone push [--stack=<stack-name>] --app=<app-name> --env=<env-name> [optio
 | `--source` | The source artifact to push that contains your application's build.		For a container, specify the name of the docker image to push. This follows the same syntax as 'docker push NAME[:TAG]'.		For a serverless zip application, specify the .zip archive to push.		For a static site, specify the directory to push. | required |
 | `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
 | `--unique` | Use this to *always* push the artifact with a unique version. If the input version already exists, an incrementing `-`count`` suffix is added. |  |
+
+
+## release
+Make your infra and app code live through a single workflow. Nullstone runs an infra-update when there are outstanding workspace changes and a deploy for the resolved app version, picking the optimal, most reliable path.
+
+#### Usage
+```shell
+$ nullstone release [--stack=<stack-name>] --app=<app-name> --env=<env-name> [options]
+```
+
+#### Options
+| Option | Description | |
+| --- | --- | --- |
+| `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
+| `--app` | Name of the app to use for this operation |  |
+| `--env` | Name of the environment to use for this operation |  |
+| `--version` | Provide a label for your deployment.		If not provided, it will default to the commit sha of the repo for the current directory. |  |
+| `--env-var, -e` | Set an additional environment variable on the app for this deployment in the form KEY=VALUE.		Can be specified multiple times. Values may reference other --env-var values or standard env vars		(e.g. NULLSTONE_VERSION) using {{ VAR }}, but cannot reference secrets.		These env vars apply to this deployment only; a subsequent infra run or deploy may overwrite them. |  |
+| `--auto-approve` | Skip any approvals on the infra-update. This requires proper permissions in the stack. |  |
+| `--wait, -w` | Wait for the release to complete and stream the logs to the console. |  |
 
 
 ## run

--- a/docs/main.go
+++ b/docs/main.go
@@ -6,8 +6,19 @@ import (
 	"gopkg.in/nullstone-io/nullstone.v0/app"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 )
+
+// vueInterpolation matches Mustache-style "{{ ... }}" sequences that the
+// VitePress compiler would otherwise try to evaluate as Vue interpolation.
+var vueInterpolation = regexp.MustCompile(`\{\{[^}]*\}\}`)
+
+// escapeVueInterpolation wraps any "{{ ... }}" sequences in <code v-pre>...</code>
+// so the docs site renders them literally instead of failing to compile them.
+func escapeVueInterpolation(s string) string {
+	return vueInterpolation.ReplaceAllString(s, "<code v-pre>$0</code>")
+}
 
 func main() {
 	log.Println("Generating CLI docs...")
@@ -43,7 +54,7 @@ func formatUsageText(usageText string) string {
 	result := strings.Replace(usageText, "\n", "", -1)
 	result = strings.Replace(result, "<", "`", -1)
 	result = strings.Replace(result, ">", "`", -1)
-	return result
+	return escapeVueInterpolation(result)
 }
 
 func formatFlagName(name string, aliases []string) string {
@@ -64,7 +75,7 @@ func outputCommandDescription(f *os.File, name string, description string) {
 	if name == "version" {
 		f.WriteString("Prints the version of the CLI.\n\n")
 	} else {
-		f.WriteString(description + "\n\n")
+		f.WriteString(escapeVueInterpolation(description) + "\n\n")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260529014244-6ac251566d0e
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005 h1:s+bMuHog7gYUKxg4co7u/o9udGCouORUK82ExKPmmRE=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260520222828-989095fec005/go.mod h1:THcJidhDCJRYgp6J/Xo8KV2LkK+peC5qcFVWRN1TCMw=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260529014244-6ac251566d0e h1:NEN5YPoVBICwRjnb9c7f5ScC4bFaRQeAY8iqsdWOOgk=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260529014244-6ac251566d0e/go.mod h1:THcJidhDCJRYgp6J/Xo8KV2LkK+peC5qcFVWRN1TCMw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This adds a new CLI command `nullstone release` which allows a user to:
1. perform a deployment on several apps all at once
2. perform infra-update (optional) + deploy for each app (infra-update is only performed if there are unapplied workspace changes)

### TODO
- [x] Update the logging to report updates to each app deployment.
- [x] Provide a way to perform without waiting for completion.