### PR TITLE
Added `NULLSTONE_TRIGGER`, `NULLSTONE_TRIGGER_NAME` to `nullstone run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.185 (Jun 10, 2026)
+* Added `NULLSTONE_TRIGGER=manual` and `NULLSTONE_TRIGGER_NAME=<user-name>` env vars to job when performing `nullstone run`.
+
 # 0.0.184 (Jun 04, 2026)
 * Adjusted `nullstone release` and `nullstone deploy` to wait for deployment before streaming deploy logs.
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,10 +56,7 @@ var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Comma
 				}
 
 				rawEnvVars := c.StringSlice(RunEnvVarFlag.Name)
-				var envVars map[string]string
-				if len(rawEnvVars) > 0 {
-					envVars = make(map[string]string)
-				}
+				envVars := make(map[string]string)
 				for _, raw := range rawEnvVars {
 					before, after, ok := strings.Cut(raw, "=")
 					if !ok {
@@ -67,6 +64,8 @@ var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Comma
 					}
 					envVars[before] = after
 				}
+				envVars["NULLSTONE_TRIGGER"] = "manual"
+				envVars["NULLSTONE_TRIGGER_NAME"] = user.Name
 
 				source := outputs.ApiRetrieverSource{Config: cfg}
 				osWriters := logging.StandardOsWriters{}


### PR DESCRIPTION
When a user performs `nullstone run`, we now add `NULLSTONE_TRIGGER=manual` and `NULLSTONE_TRIGGER_NAME=<user-name>` to the env vars of the job.