### PR TITLE
feat(modules): support app_type in manifest, register, find, list, describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.194 (Aug 26, 2026)
+* Added `app_type` (`generic`|`packaged`) to module manifests to distinguish generic app patterns from packaged apps; `nullstone modules register` sends it to the registry.
+* Added an App Type prompt to `nullstone modules generate` for app modules.
+* Added `--app-type` filter to `nullstone modules find` and `nullstone modules list`; `nullstone modules describe` displays it.
+
 # 0.0.193 (Aug 25, 2026)
 * Fixed `--env-var` and `--var` values containing commas being split into fragments. ([#673](https://github.com/nullstone-io/nullstone/issues/673))
 

--- a/cmd/module_survey.go
+++ b/cmd/module_survey.go
@@ -125,6 +125,24 @@ func (m *moduleSurvey) Ask(cfg api.Config, defaults *types.ModuleManifest) (*typ
 	}
 	manifest.Subcategory = strings.ToLower(manifest.Subcategory)
 
+	// App Type
+	if manifest.Category == string(types.CategoryApp) {
+		appTypePrompt := &survey.Select{
+			Message: "App Type:",
+			Options: types.AllAppTypeNames,
+			Help:    "'generic' apps deploy your own code; 'packaged' apps ship a ready-to-run application with no user code",
+			Default: string(types.AppTypeGeneric),
+		}
+		if manifest.AppType != "" && slices.Contains(types.AllAppTypeNames, manifest.AppType) {
+			appTypePrompt.Default = manifest.AppType
+		}
+		if err := survey.AskOne(appTypePrompt, &manifest.AppType); err != nil {
+			return nil, err
+		}
+	} else {
+		manifest.AppType = ""
+	}
+
 	// App Categories
 	if strings.HasPrefix(manifest.Category, "capability") {
 		// We are splitting category and subcategory

--- a/cmd/modules.go
+++ b/cmd/modules.go
@@ -66,6 +66,10 @@ var ModulesList = &cli.Command{
 			Usage: "Filter modules by subcategory. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry",
 		},
 		&cli.StringFlag{
+			Name:  "app-type",
+			Usage: "Filter app modules by app type. Known values: generic, packaged",
+		},
+		&cli.StringFlag{
 			Name:  "provider",
 			Usage: "Filter modules by provider type. Known values: aws, gcp, azure",
 		},
@@ -90,6 +94,7 @@ var ModulesList = &cli.Command{
 			nameFilter := c.String("name")
 			categoryFilter := c.String("category")
 			subcategoryFilter := c.String("subcategory")
+			appTypeFilter := c.String("app-type")
 			providerFilter := c.String("provider")
 			platformFilter := c.String("platform")
 			subplatformFilter := c.String("subplatform")
@@ -103,6 +108,9 @@ var ModulesList = &cli.Command{
 					continue
 				}
 				if subcategoryFilter != "" && string(module.Subcategory) != subcategoryFilter {
+					continue
+				}
+				if appTypeFilter != "" && string(module.AppType) != appTypeFilter {
 					continue
 				}
 				if providerFilter != "" && !slices.Contains(module.ProviderTypes, providerFilter) {

--- a/cmd/modules_describe.go
+++ b/cmd/modules_describe.go
@@ -156,6 +156,9 @@ func writeModuleDescribePretty(w *os.File, out moduleDescribeOutput) {
 		category = fmt.Sprintf("%s/%s", category, m.Subcategory)
 	}
 	rows = append(rows, fmt.Sprintf("Category|%s", category))
+	if m.AppType != "" {
+		rows = append(rows, fmt.Sprintf("App Type|%s", m.AppType))
+	}
 	if len(m.ProviderTypes) > 0 {
 		rows = append(rows, fmt.Sprintf("Providers|%s", strings.Join(m.ProviderTypes, ", ")))
 	}

--- a/cmd/modules_find.go
+++ b/cmd/modules_find.go
@@ -19,7 +19,7 @@ var ModulesFind = &cli.Command{
 		"To list modules owned by your organization, use `nullstone modules list`. " +
 		"When `--contributor` is not specified, results include Nullstone-official and your organization's modules.",
 	Usage:     "Search the Nullstone module registry",
-	UsageText: "nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]",
+	UsageText: "nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--app-type=<app-type>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "category",
@@ -28,6 +28,10 @@ var ModulesFind = &cli.Command{
 		&cli.StringFlag{
 			Name:  "subcategory",
 			Usage: "Filter modules by subcategory. Requires --category. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry",
+		},
+		&cli.StringFlag{
+			Name:  "app-type",
+			Usage: "Filter app modules by app type. Known values: generic, packaged",
 		},
 		&cli.StringFlag{
 			Name:  "provider",
@@ -83,6 +87,10 @@ var ModulesFind = &cli.Command{
 		if c.IsSet("subcategory") {
 			v := c.String("subcategory")
 			input.Subcategory = &v
+		}
+		if c.IsSet("app-type") {
+			v := c.String("app-type")
+			input.AppType = &v
 		}
 		if c.IsSet("provider") {
 			v := c.String("provider")

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260716142317-86afc1414450
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260826140919-a94f97f2a927
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -244,5 +244,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace gopkg.in/nullstone-io/go-api-client.v0 => ../go-api-client

--- a/go.mod
+++ b/go.mod
@@ -244,3 +244,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace gopkg.in/nullstone-io/go-api-client.v0 => ../go-api-client

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,6 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260716142317-86afc1414450 h1:SyaPK1+amJ5rwLGrdcyZrfQP9OGiraM3xdfImfYip4A=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260716142317-86afc1414450/go.mod h1:x8ZIKxEsL+/OU6/Jtspf1YtKXca41kOtwNw+GTZt7As=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -572,6 +572,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260826140919-a94f97f2a927 h1:ENSLevZXfX6+18L6Os0hcbRpR525PeKy8t8LevVURH4=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260826140919-a94f97f2a927/go.mod h1:x8ZIKxEsL+/OU6/Jtspf1YtKXca41kOtwNw+GTZt7As=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/modules/manifest.go
+++ b/modules/manifest.go
@@ -63,5 +63,8 @@ func WriteManifestToLogger(manifest types.ModuleManifest, logger *log.Logger) {
 	logger.Println(fmt.Sprintf("Module: %s/%s", manifest.OrgName, manifest.Name))
 	logger.Println(fmt.Sprintf("URL: %s", manifest.SourceUrl))
 	logger.Println(fmt.Sprintf("Contract: %s%s/%s/%s%s", manifest.Category, subcategory, provider, manifest.Platform, subplatform))
+	if manifest.AppType != "" {
+		logger.Println(fmt.Sprintf("App Type: %s", manifest.AppType))
+	}
 	logger.Println(fmt.Sprintf("Tool: %s", manifest.ToolName))
 }

--- a/modules/register.go
+++ b/modules/register.go
@@ -19,6 +19,7 @@ func Register(ctx context.Context, cfg api.Config, manifest *types.ModuleManifes
 		IsPublic:      manifest.IsPublic,
 		Category:      manifest.Category,
 		Subcategory:   manifest.Subcategory,
+		AppType:       manifest.AppType,
 		ProviderTypes: manifest.ProviderTypes,
 		Platform:      manifest.Platform,
 		Subplatform:   manifest.Subplatform,


### PR DESCRIPTION
Part of [NUL-191](https://linear.app/nullstone/issue/NUL-191/separate-generic-app-patterns-from-packaged-apps-in-module-manifest). Pairs with nullstone-io/oracle#94.

- `.nullstone/module.yml` supports `app_type: generic | packaged` for app modules; `modules register` sends it to the registry (absent = generic)
- `modules generate` survey prompts for App Type on app modules (defaults to generic)
- `--app-type` filter on `modules find` (server-side) and `modules list` (client-side)
- `modules describe` and package logging display the app type
- Pins go-api-client to master (`a94f97f`) which carries the new `AppType` field

Manifests without `app_type` behave exactly as before.