### PR TITLE
feat(outputs): add --field flag to emit a single output value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.195 (Aug 28, 2026)
+* Added `--field` to `nullstone outputs` to emit a single output value for command substitution; supports Terraform-style traversal (e.g. `endpoint.host`, `hosts[0]`).
+
 # 0.0.194 (Aug 26, 2026)
 * Added `app_type` (`generic`|`packaged`) to module manifests to distinguish generic app patterns from packaged apps; `nullstone modules register` sends it to the registry.
 * Added an App Type prompt to `nullstone modules generate` for app modules.

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
@@ -13,9 +14,9 @@ import (
 var Outputs = func() *cli.Command {
 	return &cli.Command{
 		Name:        "outputs",
-		Description: "Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. You must have proper permissions in order to use the `--sensitive` flag. For less information in an easier to read format, use the `--plain` flag.",
+		Description: "Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. You must have proper permissions in order to use the `--sensitive` flag. For less information in an easier to read format, use the `--plain` flag. Use the `--field` flag to emit a single output value suitable for command substitution in scripts.",
 		Usage:       "Retrieve outputs",
-		UsageText:   "nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
+		UsageText:   "nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [--field=<expression>] [options]",
 		Flags: []cli.Flag{
 			StackFlag,
 			BlockFlag,
@@ -28,6 +29,10 @@ var Outputs = func() *cli.Command {
 				Name:  "plain",
 				Usage: "Print less information about the outputs in a more readable format",
 			},
+			&cli.StringFlag{
+				Name:  "field",
+				Usage: `Print a single output value using Terraform-style syntax (e.g. instance_id, endpoint.host, hosts[0], hosts["item1"]). Strings print raw; other values print as compact JSON. Takes precedence over --plain.`,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return BlockWorkspaceAction(c, func(ctx context.Context, cfg api.Config, stack types.Stack, block types.Block, env types.Environment, workspace types.Workspace) error {
@@ -36,6 +41,19 @@ var Outputs = func() *cli.Command {
 				outputs, err := client.WorkspaceOutputs().GetCurrent(ctx, stack.Id, workspace.Uid, showSensitive)
 				if err != nil {
 					return err
+				}
+
+				if c.IsSet("field") {
+					val, err := resolveOutputField(outputs, c.String("field"))
+					if err != nil {
+						return err
+					}
+					formatted, err := formatOutputValue(val)
+					if err != nil {
+						return err
+					}
+					fmt.Println(formatted)
+					return nil
 				}
 
 				for key, output := range outputs {

--- a/cmd/outputs_field.go
+++ b/cmd/outputs_field.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+// resolveOutputField resolves a Terraform-style traversal expression
+// (e.g. `instance_id`, `endpoint.host`, `hosts[0]`, `hosts["item1"]`)
+// against a set of workspace outputs.
+func resolveOutputField(outputs types.Outputs, expr string) (any, error) {
+	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(expr), "--field", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("invalid --field expression %q: %s", expr, diags.Error())
+	}
+
+	rootName := traversal.RootName()
+	output, ok := outputs[rootName]
+	if !ok {
+		return nil, fmt.Errorf("output %q not found (available outputs: %s)", rootName, strings.Join(outputNames(outputs), ", "))
+	}
+	if output.Redacted {
+		return nil, fmt.Errorf("output %q is sensitive; re-run with --sensitive to emit its value", rootName)
+	}
+
+	cur := output.Value
+	path := rootName
+	for _, traverser := range traversal[1:] {
+		var err error
+		switch t := traverser.(type) {
+		case hcl.TraverseAttr:
+			cur, err = traverseKey(cur, t.Name, path)
+			path = fmt.Sprintf("%s.%s", path, t.Name)
+		case hcl.TraverseIndex:
+			switch t.Key.Type() {
+			case cty.String:
+				key := t.Key.AsString()
+				cur, err = traverseKey(cur, key, path)
+				path = fmt.Sprintf("%s[%q]", path, key)
+			case cty.Number:
+				var idx int64
+				if idx, err = ctyInt(t.Key); err == nil {
+					cur, err = traverseIndex(cur, int(idx), path)
+					path = fmt.Sprintf("%s[%d]", path, idx)
+				}
+			default:
+				err = fmt.Errorf("%s: unsupported index type in --field expression", path)
+			}
+		default:
+			err = fmt.Errorf("%s: unsupported traversal in --field expression", path)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cur, nil
+}
+
+// formatOutputValue renders a resolved output value for stdout: strings are
+// emitted raw (unquoted) so they compose in command substitution; all other
+// values are compact JSON.
+func formatOutputValue(val any) (string, error) {
+	if s, ok := val.(string); ok {
+		return s, nil
+	}
+	raw, err := json.Marshal(val)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func traverseKey(val any, key string, path string) (any, error) {
+	m, ok := val.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is not an object; cannot access %q", path, key)
+	}
+	child, ok := m[key]
+	if !ok {
+		return nil, fmt.Errorf("%s has no key %q (available keys: %s)", path, key, strings.Join(mapKeys(m), ", "))
+	}
+	return child, nil
+}
+
+func traverseIndex(val any, idx int, path string) (any, error) {
+	list, ok := val.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is not a list; cannot access index %d", path, idx)
+	}
+	if idx < 0 || idx >= len(list) {
+		return nil, fmt.Errorf("%s[%d] is out of range (list has %d elements)", path, idx, len(list))
+	}
+	return list[idx], nil
+}
+
+func ctyInt(v cty.Value) (int64, error) {
+	bf := v.AsBigFloat()
+	idx, acc := bf.Int64()
+	if acc != big.Exact {
+		return 0, fmt.Errorf("index %s is not an integer", bf.String())
+	}
+	return idx, nil
+}
+
+func outputNames(outputs types.Outputs) []string {
+	names := make([]string, 0, len(outputs))
+	for name := range outputs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/outputs_field_test.go
+++ b/cmd/outputs_field_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+func TestResolveOutputField(t *testing.T) {
+	outputs := types.Outputs{
+		"instance_id": types.Output{Type: "string", Value: "i-0abc123"},
+		"port":        types.Output{Type: "number", Value: float64(5432)},
+		"enabled":     types.Output{Type: "bool", Value: true},
+		"hosts": types.Output{
+			Type:  []any{"list", "string"},
+			Value: []any{"host-a", "host-b"},
+		},
+		"endpoint": types.Output{
+			Type:  "object",
+			Value: map[string]any{"host": "db.example.com", "port": float64(5432)},
+		},
+		"items": types.Output{
+			Type:  "map",
+			Value: map[string]any{"item1": map[string]any{"id": "abc"}},
+		},
+		"db_password": types.Output{Type: "string", Value: "(hidden)", Sensitive: true, Redacted: true},
+	}
+
+	tests := []struct {
+		name    string
+		expr    string
+		want    any
+		wantErr string
+	}{
+		{name: "top-level string", expr: "instance_id", want: "i-0abc123"},
+		{name: "top-level number", expr: "port", want: float64(5432)},
+		{name: "top-level bool", expr: "enabled", want: true},
+		{name: "list index", expr: "hosts[0]", want: "host-a"},
+		{name: "attr access", expr: "endpoint.host", want: "db.example.com"},
+		{name: "quoted map key", expr: `items["item1"]`, want: map[string]any{"id": "abc"}},
+		{name: "quoted key then attr", expr: `items["item1"].id`, want: "abc"},
+		{name: "unknown output", expr: "missing", wantErr: `output "missing" not found`},
+		{name: "unknown key", expr: "endpoint.missing", wantErr: `endpoint has no key "missing"`},
+		{name: "index out of range", expr: "hosts[5]", wantErr: "hosts[5] is out of range"},
+		{name: "index into scalar", expr: "instance_id[0]", wantErr: "instance_id is not a list"},
+		{name: "attr on scalar", expr: "instance_id.foo", wantErr: "instance_id is not an object"},
+		{name: "redacted output", expr: "db_password", wantErr: `output "db_password" is sensitive`},
+		{name: "invalid expression", expr: "hosts[", wantErr: "invalid --field expression"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveOutputField(outputs, tt.expr)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got value %v", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			gotStr, _ := formatOutputValue(got)
+			wantStr, _ := formatOutputValue(tt.want)
+			if gotStr != wantStr {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatOutputValue(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want string
+	}{
+		{name: "string is raw", val: "i-0abc123", want: "i-0abc123"},
+		{name: "string with spaces is unquoted", val: "hello world", want: "hello world"},
+		{name: "number", val: float64(5432), want: "5432"},
+		{name: "bool", val: true, want: "true"},
+		{name: "nil", val: nil, want: "null"},
+		{name: "list is compact json", val: []any{"a", "b"}, want: `["a","b"]`},
+		{name: "map is compact json", val: map[string]any{"host": "db", "port": float64(1)}, want: `{"host":"db","port":1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := formatOutputValue(tt.val)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -354,6 +354,7 @@ $ nullstone modules list
 | `--name` | Filter modules whose name contains this value |  |
 | `--category` | Filter modules by category. Known values: app, capability, datastore, ingress, subdomain, domain, cluster, cluster-namespace, network, block |  |
 | `--subcategory` | Filter modules by subcategory. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry |  |
+| `--app-type` | Filter app modules by app type. Known values: generic, packaged |  |
 | `--provider` | Filter modules by provider type. Known values: aws, gcp, azure |  |
 | `--platform` | Filter modules by platform |  |
 | `--subplatform` | Filter modules by subplatform |  |
@@ -364,7 +365,7 @@ Search the entire Nullstone module registry across Nullstone-official, your org,
 
 #### Usage
 ```shell
-$ nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]
+$ nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [--app-type=<app-type>] [--provider=<provider>] [--platform=<platform>] [--subplatform=<subplatform>] [--name=<name>] [--contributor=<contributor>]... [--format=table|json]
 ```
 
 #### Options
@@ -372,6 +373,7 @@ $ nullstone modules find [--category=<category>] [--subcategory=<subcategory>] [
 | --- | --- | --- |
 | `--category` | Filter modules by category. Known values: app, capability, datastore, ingress, subdomain, domain, cluster, cluster-namespace, network, block |  |
 | `--subcategory` | Filter modules by subcategory. Requires --category. Known values — app: container, serverless, static-site, server; capability: ingress, datastores, secrets, sidecars, events, telemetry |  |
+| `--app-type` | Filter app modules by app type. Known values: generic, packaged |  |
 | `--provider` | Filter modules by provider type. Known values: aws, gcp, azure |  |
 | `--platform` | Filter modules by platform |  |
 | `--subplatform` | Filter modules by subplatform. Requires --platform. |  |
@@ -440,11 +442,11 @@ $ nullstone modules package
 
 
 ## outputs
-Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. You must have proper permissions in order to use the `--sensitive` flag. For less information in an easier to read format, use the `--plain` flag.
+Print all the module outputs for a given block and environment. Provide the `--sensitive` flag to include sensitive outputs in the results. You must have proper permissions in order to use the `--sensitive` flag. For less information in an easier to read format, use the `--plain` flag. Use the `--field` flag to emit a single output value suitable for command substitution in scripts.
 
 #### Usage
 ```shell
-$ nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]
+$ nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name> [--field=<expression>] [options]
 ```
 
 #### Options
@@ -455,6 +457,7 @@ $ nullstone outputs [--stack=<stack-name>] --block=<block-name> --env=<env-name>
 | `--env` | Name of the environment to use for this operation | required |
 | `--sensitive` | Include sensitive outputs in the results |  |
 | `--plain` | Print less information about the outputs in a more readable format |  |
+| `--field` | Print a single output value using Terraform-style syntax (e.g. instance_id, endpoint.host, hosts[0], hosts["item1"]). Strings print raw; other values print as compact JSON. Takes precedence over --plain. |  |
 
 
 ## plan

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -59,7 +59,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/tmccombs/hcl2json v0.6.9 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.19.0 // indirect
+	github.com/zclconf/go-cty v1.19.0
 	golang.org/x/mod v0.38.0
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -146,6 +146,9 @@ func outputsTool() mcp.Tool {
 			mcp.WithBoolean("plain",
 				mcp.Description("Return simplified key-value pairs without type metadata."),
 			),
+			mcp.WithString("field",
+				mcp.Description(`Emit a single output value using Terraform-style syntax (e.g. "instance_id", "endpoint.host", "hosts[0]", "hosts[\"item1\"]"). Strings are returned raw; other values as compact JSON. Takes precedence over plain.`),
+			),
 		)...,
 	)
 }


### PR DESCRIPTION
## Summary
Adds `--field` to `nullstone outputs` to print a single output value, suitable for command substitution in scripts (NUL-192):

```bash
aws ssm start-session --target $(nullstone outputs --block=<app> --env=<env> --field=instance_id)
```

- Terraform-style traversal via `hclsyntax.ParseTraversalAbs` (already in the dep tree): `instance_id`, `endpoint.host`, `hosts[0]`, `hosts[item1]`
- Strings print raw/unquoted; numbers, bools, lists, maps print as compact JSON (jq-composable)
- Non-zero exit with descriptive errors: unknown output (lists available names), bad path (reports the failing path segment), index out of range
- Sensitive outputs without `--sensitive` error instead of emitting `(hidden)` into stdout
- `--field` takes precedence over `--plain`
- MCP `outputs` tool gains a matching `field` param (executor already forwards params as flags)
- Regenerated `docs/CLI.md` (also picks up stale `--app-type` rows from #675)
- Changelog entry under 0.0.195

## Testing
- New table-driven tests in `cmd/outputs_field_test.go` covering traversal, formatting, and all error paths
- Full `go test ./...` green

Closes NUL-192