### PR TITLE
feat: add --for=deployed to nullstone wait (NUL-193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.196 (Aug 31, 2026)
+* Added `--for=deployed` to `nullstone wait` to wait for an app to deploy successfully.
+
 # 0.0.195 (Aug 28, 2026)
 * Added `--field` to `nullstone outputs` to emit a single output value for command substitution; supports Terraform-style traversal (e.g. `endpoint.host`, `hosts[0]`).
 

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -18,9 +18,9 @@ import (
 var (
 	WaitForFlag = &cli.StringFlag{
 		Name: "for",
-		Usage: `Configure the wait command to reach a specific status. 
-       Currently this supports --for=launched.
-       In the future, we will support --for=destroyed and --for=deployed`,
+		Usage: `Configure the wait command to reach a specific status.
+       Currently this supports --for=launched and --for=deployed.
+       In the future, we will support --for=destroyed`,
 	}
 	WaitTimeoutFlag = &cli.DurationFlag{
 		Name:  "timeout",
@@ -44,8 +44,9 @@ var Wait = func() *cli.Command {
 		Name: "wait",
 		Description: `Waits for a workspace to reach a specific status.
 This is helpful to wait for infrastructure to provision or an app to deploy.
-Currently, this supports --for=launched to wait for a workspace to provision.
-In the future, we will add --for=destroyed and --for=deployed.`,
+Currently, this supports --for=launched to wait for a workspace to provision
+and --for=deployed to wait for an app to deploy successfully.
+In the future, we will add --for=destroyed.`,
 		Usage:     "Wait for a block to launch, destroy, or deploy in an environment.",
 		UsageText: "nullstone wait [--stack=<stack-name>] --block=<block-name> --env=<env-name> [options]",
 		Flags: []cli.Flag{
@@ -72,6 +73,8 @@ In the future, we will add --for=destroyed and --for=deployed.`,
 				switch strings.ToLower(waitFor) {
 				case "launched":
 					return WaitForLaunch(ctx, osWriters, cfg, details, timeout, approvalTimeout)
+				case "deployed":
+					return WaitForDeployed(ctx, osWriters, cfg, details, timeout)
 				default:
 					return fmt.Errorf("The wait command does not support --for=%s", waitFor)
 				}

--- a/cmd/wait_for_deployed.go
+++ b/cmd/wait_for_deployed.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/nullstone.v0/app_urls"
+	"time"
+)
+
+var waitForDeployedPollDelay = 2 * time.Second
+
+// WaitForDeployed waits for an app to reach a successful deployment in an environment.
+// Launches and deploys can start out-of-band (CI, the UI, another terminal), so this must tolerate
+// any starting condition: not provisioned yet, launch in progress, deploy triggered but the deploy
+// record not created yet, deploy in flight, or already deployed.
+//
+// Each poll inspects the latest deploy and the newest workspace workflow:
+//   - the latest deploy completed and no workflow started after it -> success
+//   - anything else (no deploy yet, deploy in flight, failed/cancelled deploy that may be retried,
+//     workflow running) -> keep waiting until a deploy succeeds or the timeout expires
+func WaitForDeployed(ctx context.Context, osWriters logging.OsWriters, cfg api.Config, details workspace.Details, timeout time.Duration) error {
+	stderr := osWriters.Stderr()
+	if details.Block.Type != string(types.BlockTypeApplication) {
+		return fmt.Errorf("The wait command with --for=deployed only supports apps; %q is a %s", details.Block.Name, details.Block.Type)
+	}
+
+	fmt.Fprintf(stderr, "Waiting for %q to deploy in %q environment...\n", details.Block.Name, details.Env.Name)
+	fmt.Fprintf(stderr, "Timeout = %s\n", timeout)
+
+	client := api.Client{Config: cfg}
+	stackId, appId, envId := details.Block.StackId, details.Block.Id, details.Env.Id
+
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	var lastDeploy *types.Deploy
+	firstCheck := true
+	reportedQuiet := false
+	reportedWorkflowId := int64(0)
+	lastReported := ""
+	for {
+		deploy, err := client.Deploys().GetLatest(ctx, stackId, appId, envId, nil)
+		if err != nil {
+			return fmt.Errorf("error retrieving latest deploy: %w", err)
+		}
+		if deploy != nil {
+			lastDeploy = deploy
+		}
+
+		wflows, err := client.WorkspaceWorkflows().List(ctx, stackId, appId, envId, 1, 1)
+		if err != nil {
+			return fmt.Errorf("error retrieving workspace workflows: %w", err)
+		}
+		var newestWorkflow *types.WorkspaceWorkflow
+		if len(wflows) > 0 {
+			newestWorkflow = &wflows[0]
+		}
+		hasActivity := newestWorkflow != nil && !types.IsTerminalWorkspaceWorkflow(newestWorkflow.Status)
+		if hasActivity && newestWorkflow.Id != reportedWorkflowId {
+			reportedWorkflowId = newestWorkflow.Id
+			fmt.Fprintf(stderr, "Workflow %q is in progress: %s\n", newestWorkflow.FriendlyAction, app_urls.GetWorkspaceWorkflow(cfg, *newestWorkflow, true))
+		}
+
+		if deploy != nil {
+			reported := fmt.Sprintf("%d:%s", deploy.Id, deploy.Status)
+			switch deploy.Status {
+			case types.DeployStatusCompleted:
+				// A workflow created after this deploy is producing a newer deploy; this one is stale
+				if !hasActivity || !newestWorkflow.CreatedAt.After(deploy.CreatedAt) {
+					if firstCheck {
+						fmt.Fprintln(stderr, "App has deployed already.")
+					} else {
+						fmt.Fprintln(stderr, "App deployed successfully.")
+					}
+					return nil
+				}
+			case types.DeployStatusFailed, types.DeployStatusCancelled:
+				// A failed/cancelled deploy may be retried out-of-band; wait for new activity until timeout
+				if reported != lastReported {
+					fmt.Fprintf(stderr, "Deploy %s %s; waiting for a new deploy to start...\n", deployLabel(*deploy), deploy.Status)
+				}
+			default: // queued, initializing, running
+				if reported != lastReported {
+					fmt.Fprintf(stderr, "Deploy %s is %s...\n", deployLabel(*deploy), deploy.Status)
+				}
+			}
+			lastReported = reported
+		} else if !hasActivity && !reportedQuiet {
+			reportedQuiet = true
+			fmt.Fprintln(stderr, "No deploy has started yet. Waiting for a deploy to start...")
+		}
+		firstCheck = false
+
+		select {
+		case <-time.After(waitForDeployedPollDelay):
+		case <-timeoutTimer.C:
+			fmt.Fprintln(stderr, "Timed out waiting for app to deploy.")
+			if lastDeploy != nil {
+				switch lastDeploy.Status {
+				case types.DeployStatusFailed, types.DeployStatusCancelled:
+					return fmt.Errorf("Operation cancelled waiting for deploy; deploy %s finished with %q status: %s", deployLabel(*lastDeploy), lastDeploy.Status, lastDeploy.StatusMessage)
+				}
+			}
+			return fmt.Errorf("Operation cancelled waiting for deploy")
+		case <-ctx.Done():
+			return fmt.Errorf("User cancelled operation")
+		}
+	}
+}
+
+func deployLabel(deploy types.Deploy) string {
+	if deploy.Reference != "" {
+		return deploy.Reference
+	}
+	return fmt.Sprintf("#%d", deploy.Id)
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -718,8 +718,9 @@ nullstone -v
 ## wait
 Waits for a workspace to reach a specific status.
 This is helpful to wait for infrastructure to provision or an app to deploy.
-Currently, this supports --for=launched to wait for a workspace to provision.
-In the future, we will add --for=destroyed and --for=deployed.
+Currently, this supports --for=launched to wait for a workspace to provision
+and --for=deployed to wait for an app to deploy successfully.
+In the future, we will add --for=destroyed.
 
 #### Usage
 ```shell
@@ -732,7 +733,7 @@ $ nullstone wait [--stack=<stack-name>] --block=<block-name> --env=<env-name> [o
 | `--stack` | Scope this operation to a specific stack. This is only required if there are multiple blocks/apps with the same name. |  |
 | `--block` | Name of the block to use for this operation | required |
 | `--env` | Name of the environment to use for this operation | required |
-| `--for` | Configure the wait command to reach a specific status.        Currently this supports --for=launched.       In the future, we will support --for=destroyed and --for=deployed |  |
+| `--for` | Configure the wait command to reach a specific status.       Currently this supports --for=launched and --for=deployed.       In the future, we will support --for=destroyed |  |
 | `--timeout` | Set --timeout to a golang duration to control how long to wait for a status before cancelling.       The default is '1h' (1 hour).       |  |
 | `--approval-timeout` | Set --approval-timeout to a golang duration to control how long to wait for approval before cancelling.       If the workspace run never reaches "needs-approval", this has no effect.       The default is '15m' (15 minutes).       |  |
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -413,7 +413,7 @@ func waitTool() mcp.Tool {
 				mcp.Description("Name of the environment."),
 			),
 			mcp.WithString("for",
-				mcp.Description("Status to wait for. Currently supported: 'launched'."),
+				mcp.Description("Status to wait for. Currently supported: 'launched', 'deployed'."),
 			),
 			mcp.WithString("timeout",
 				mcp.Description("Max wait time as a Go duration. Default: '1h'. Examples: '30m', '2h'."),


### PR DESCRIPTION
Adds `--for=deployed` to `nullstone wait` so users can wait for an app to reach a successful deployment.

Linear: [NUL-193](https://linear.app/nullstone/issue/NUL-193/add-support-for-fordeployed-to-nullstone-wait-command)

## Behavior

Launches/deploys can start out-of-band (CI, UI, another terminal), so this is resilient to any starting state. Each poll (2s, bounded by `--timeout`, default 1h) inspects the latest deploy and the newest workspace workflow:

- Latest deploy `completed` and no workflow started after it → success immediately (current-state semantics).
- Deploy in flight (`queued`/`initializing`/`running`) → keep waiting, printing status transitions.
- Latest deploy `failed`/`cancelled` → keep waiting for an out-of-band retry; on timeout, the error cites the failed deploy.
- Nothing exists yet (not provisioned / launching / no deploy row) → keep polling until `--timeout`.
- A non-terminal workspace workflow counts as activity — this closes the race where a release flips to running before its deploy row is created (server lists workflows `created_at DESC`, so `List(page=1, perPage=1)` is the newest).

Output is quiet status transitions only (plus the workflow URL); log streaming stays in `deploy --wait` / `nullstone logs`. `--approval-timeout` is not used (deploys have no approval phase). Non-app blocks get a clear error.

## Changes

- `cmd/wait_for_deployed.go`: new `WaitForDeployed` poll loop
- `cmd/wait.go`: flag/description text + dispatch
- `mcp/tools.go`: wait tool now advertises `deployed`
- `docs/CLI.md`: regenerated (`go run ./docs`)
- `CHANGELOG.md`: 0.0.196 entry

## Verification

- `go build ./...` clean, `go test ./...` green
- Manual smoke test recommended before release: async `nullstone deploy`, then `nullstone wait --for=deployed`