### PR TITLE
fix: decode paginated response in `nullstone wait` workflow lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.197 (Aug 31, 2026)
+* Fixed errors occuring in `nullstone wait` command when listing workspace workflows.
+
 # 0.0.196 (Aug 31, 2026)
 * Added `--for=deployed` to `nullstone wait` to wait for an app to deploy successfully.
 * Added `nullstone preview-apps find` to search a stack's preview apps by `--repo` and `--pull-request`, so CI can discover the preview environment created for a pull request.

--- a/cmd/wait_for_deployed.go
+++ b/cmd/wait_for_deployed.go
@@ -51,7 +51,7 @@ func WaitForDeployed(ctx context.Context, osWriters logging.OsWriters, cfg api.C
 			lastDeploy = deploy
 		}
 
-		wflows, err := client.WorkspaceWorkflows().List(ctx, stackId, appId, envId, 1, 1)
+		wflows, _, err := client.WorkspaceWorkflows().List(ctx, stackId, appId, envId, 1, 1)
 		if err != nil {
 			return fmt.Errorf("error retrieving workspace workflows: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260831211934-b549f11304fa
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260901010111-47d8f97fa989
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260831211934-b549f11304fa h1:rXsB78e8AVAS8UNRRJjUHtimCXUGRhkEAKbhJgJvbX4=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260831211934-b549f11304fa/go.mod h1:x8ZIKxEsL+/OU6/Jtspf1YtKXca41kOtwNw+GTZt7As=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260901010111-47d8f97fa989 h1:6Mr4SshTcB971h8pxBt3lRTxwCRZ5oxqcrnK+QBQBT4=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260901010111-47d8f97fa989/go.mod h1:x8ZIKxEsL+/OU6/Jtspf1YtKXca41kOtwNw+GTZt7As=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
`nullstone wait --for=deployed` failed with:

```
error retrieving workspace workflows: error decoding json body: json: cannot unmarshal object into Go value of type []types.WorkspaceWorkflow
```

The list endpoint returns `{ workflows, total }` (nullfire `WorkspaceWorkflowsQueryResult`, which razor already relies on for pagination), but go-api-client decoded a bare array.

The decoding fix landed in go-api-client (`WorkspaceWorkflows.List` now returns `([]types.WorkspaceWorkflow, int, error)`, decoding the wrapper). This PR bumps that dependency and updates the only caller.

## Changes
- Bump `go-api-client` to `v0.0.0-20260901010111-47d8f97fa989`
- `cmd/wait_for_deployed.go`: take the new total return value (unused here — the caller only needs the newest workflow)
- CHANGELOG entry for 0.0.197
