### PR TITLE
fix: allow run/exec with an org api key by falling back attribution username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.198 (Sep 1, 2026)
+* Fixed `nullstone run` and `nullstone exec` failing with "unable to fetch the current user" when authenticated with an organization API key; attribution falls back to `org-api-key`.
+
 # 0.0.197 (Aug 31, 2026)
 * Fixed errors occuring in `nullstone wait` command when listing workspace workflows.
 

--- a/cmd/current_username.go
+++ b/cmd/current_username.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/response"
+)
+
+// OrgApiKeyUsername is the attribution name (e.g. NULLSTONE_TRIGGER_NAME, ECS "started by")
+// used when the CLI is authenticated with an organization API key.
+// Org API keys are not backed by a user, so the API rejects /current_user for them.
+const OrgApiKeyUsername = "org-api-key"
+
+// orgApiKeyUnsupportedErrorType is the API error type emitted when an endpoint
+// that acts on behalf of a user is called with an organization API key.
+const orgApiKeyUnsupportedErrorType = "problems/org-api-key-unsupported"
+
+// getCurrentUsername resolves a display name for the current credentials to attribute run/exec commands.
+// User credentials (including personal API keys) resolve to the user's name.
+// Organization API keys have no backing user; they fall back to OrgApiKeyUsername.
+func getCurrentUsername(ctx context.Context, cfg api.Config) (string, error) {
+	client := api.Client{Config: cfg}
+	user, err := client.CurrentUser().Get(ctx)
+	if err != nil {
+		var unauthorizedErr response.UnauthorizedError
+		if errors.As(err, &unauthorizedErr) && unauthorizedErr.Type == orgApiKeyUnsupportedErrorType {
+			return OrgApiKeyUsername, nil
+		}
+		return "", fmt.Errorf("unable to fetch the current user: %w", err)
+	}
+	if user == nil {
+		return "", fmt.Errorf("unable to load the current user info")
+	}
+	return user.Name, nil
+}

--- a/cmd/current_username_test.go
+++ b/cmd/current_username_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+)
+
+func TestGetCurrentUsername(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "user credentials resolve to the user's name",
+			status: http.StatusOK,
+			body:   `{"id":1,"name":"brad.sickles","picture":""}`,
+			want:   "brad.sickles",
+		},
+		{
+			name:   "org api key falls back to the org-api-key name",
+			status: http.StatusForbidden,
+			body:   `{"type":"problems/org-api-key-unsupported","title":"Unsupported for Organization API Key","code":403,"message":"This endpoint cannot be used with an organization API key."}`,
+			want:   OrgApiKeyUsername,
+		},
+		{
+			name:        "other 403 errors still fail",
+			status:      http.StatusForbidden,
+			body:        `{"type":"problems/authorization-error","title":"Access Denied","code":403,"message":"You do not have the proper authorization to access this resource."}`,
+			wantErr:     true,
+			errContains: "unable to fetch the current user",
+		},
+		{
+			name:        "401 errors still fail",
+			status:      http.StatusUnauthorized,
+			body:        `{"type":"problems/authentication-error","title":"Not Authenticated","code":401,"message":"You must login to access this resource."}`,
+			wantErr:     true,
+			errContains: "unable to fetch the current user",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/current_user", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(test.status)
+				w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+
+			cfg := api.Config{BaseAddress: server.URL}
+			got, err := getCurrentUsername(context.Background(), cfg)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -38,13 +38,9 @@ var Exec = func(appProviders app.Providers, providers admin.Providers) *cli.Comm
 			}
 
 			return AppWorkspaceAction(c, func(ctx context.Context, cfg api.Config, appDetails app.Details) error {
-				client := api.Client{Config: cfg}
-				user, err := client.CurrentUser().Get(ctx)
+				username, err := getCurrentUsername(ctx, cfg)
 				if err != nil {
-					return fmt.Errorf("unable to fetch the current user")
-				}
-				if user == nil {
-					return fmt.Errorf("unable to load the current user info")
+					return err
 				}
 
 				source := outputs.ApiRetrieverSource{Config: cfg}
@@ -68,7 +64,7 @@ var Exec = func(appProviders app.Providers, providers admin.Providers) *cli.Comm
 					Task:        c.String("task"),
 					Pod:         c.String("pod"),
 					Container:   c.String("container"),
-					Username:    user.Name,
+					Username:    username,
 					LogStreamer: logStreamer,
 					LogEmitter:  app.NewWriterLogEmitter(os.Stdout),
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,13 +66,9 @@ var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Comma
 			}
 
 			return AppWorkspaceAction(c, func(ctx context.Context, cfg api.Config, appDetails app.Details) error {
-				client := api.Client{Config: cfg}
-				user, err := client.CurrentUser().Get(ctx)
+				username, err := getCurrentUsername(ctx, cfg)
 				if err != nil {
-					return fmt.Errorf("unable to fetch the current user")
-				}
-				if user == nil {
-					return fmt.Errorf("unable to load the current user info")
+					return err
 				}
 
 				rawEnvVars := c.StringSlice(RunEnvVarFlag.Name)
@@ -85,7 +81,7 @@ var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Comma
 					envVars[before] = after
 				}
 				envVars[admin.TriggerEnvVar] = admin.TriggerManual
-				envVars[admin.TriggerNameEnvVar] = user.Name
+				envVars[admin.TriggerNameEnvVar] = username
 
 				source := outputs.ApiRetrieverSource{Config: cfg}
 				osWriters := logging.StandardOsWriters{}
@@ -107,7 +103,7 @@ var Run = func(appProviders app.Providers, providers admin.Providers) *cli.Comma
 				options := admin.RunOptions{
 					Container:   c.String(ContainerFlag.Name),
 					Payload:     payload,
-					Username:    user.Name,
+					Username:    username,
 					LogStreamer: logStreamer,
 					LogEmitter:  app.NewWriterLogEmitter(os.Stdout),
 				}


### PR DESCRIPTION
## Problem

`nullstone run` and `nullstone exec` fail with `unable to fetch the current user` when authenticated with an organization API key.

Both commands unconditionally call `GET /current_user` to get a display name for attribution. Org API keys are deliberately not backed by a User (their JWT `sub` is `org-api-key:<id>`), so the API rejects them with a 403 (`problems/org-api-key-unsupported`) — and the CLI aborted, even though the name is only used for attribution (`NULLSTONE_TRIGGER_NAME`, ECS started-by, Lambda client context).

## Fix

- New shared `getCurrentUsername` helper (`cmd/current_username.go`): calls `/current_user` as before, but when the API returns the specific `problems/org-api-key-unsupported` 403, falls back to the attribution name `org-api-key` instead of failing.
- Any other failure now wraps the underlying API error instead of swallowing it (previously a 401 etc. was hidden behind the generic message).
- `run` and `exec` use the helper — the only two commands with this dependency.
- Tests cover user creds, org-key 403 fallback, and generic 403/401 failures.

## Notes

The server-side 403 is left as-is; it's a documented design decision that `/current_user` has no meaning for a non-user identity. Trade-off: attribution shows the generic `org-api-key` rather than the key's name — per-key attribution would need an identity endpoint for org keys (possible follow-up).